### PR TITLE
Add comment attachment support to AST nodes

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -40,11 +40,11 @@ type literal =
 (* ------------------------------------------------------------------ *)
 
 type pattern = {
-  pat_kind : pattern_kind;
+  pat_desc : pat_desc;
   pat_comment : string option;
 }
 
-and pattern_kind =
+and pat_desc =
   | PWild                               (** _ *)
   | PVar    of string                   (** x *)
   | PLit    of literal                  (** 42, true, "s", () *)
@@ -54,18 +54,18 @@ and pattern_kind =
   | POr     of pattern * pattern        (** p1 | p2 *)
 
 (** Build a pattern node with no comment. *)
-let pat k = { pat_kind = k; pat_comment = None }
+let pat k = { pat_desc = k; pat_comment = None }
 
 (* ------------------------------------------------------------------ *)
 (* Expression AST (mutually recursive)                                  *)
 (* ------------------------------------------------------------------ *)
 
 type expr = {
-  kind    : expr_kind;
+  desc    : expr_desc;
   comment : string option;
 }
 
-and expr_kind =
+and expr_desc =
   | Var       of string
   | IntLit    of int
   | FloatLit  of float
@@ -154,7 +154,7 @@ and handle_data = {
 }
 
 (** Build an expression node with no comment. *)
-let expr k = { kind = k; comment = None }
+let expr k = { desc = k; comment = None }
 
 (* ------------------------------------------------------------------ *)
 (* Pretty-printers                                                      *)
@@ -168,12 +168,12 @@ let pp_literal fmt = function
   | LUnit     -> Format.pp_print_string fmt "LUnit"
 
 let rec pp_pattern fmt p =
-  pp_pattern_kind fmt p.pat_kind;
+  pp_pattern_desc fmt p.pat_desc;
   match p.pat_comment with
   | None   -> ()
   | Some c -> Format.fprintf fmt " @#%s#@" c
 
-and pp_pattern_kind fmt = function
+and pp_pattern_desc fmt = function
   | PWild        -> Format.pp_print_string fmt "PWild"
   | PVar s       -> Format.fprintf fmt "PVar(%S)" s
   | PLit l       -> Format.fprintf fmt "PLit(%a)" pp_literal l
@@ -218,12 +218,12 @@ let pp_param fmt { param_name; param_type } =
   Format.fprintf fmt "%s: %a" param_name pp_type_expr param_type
 
 let rec pp_expr fmt e =
-  pp_expr_kind fmt e.kind;
+  pp_expr_desc fmt e.desc;
   match e.comment with
   | None   -> ()
   | Some c -> Format.fprintf fmt " @#%s#@" c
 
-and pp_expr_kind fmt = function
+and pp_expr_desc fmt = function
   | Var s       -> Format.fprintf fmt "Var(%S)" s
   | IntLit n    -> Format.fprintf fmt "IntLit(%d)" n
   | FloatLit f  -> Format.fprintf fmt "FloatLit(%g)" f
@@ -332,9 +332,9 @@ let equal_literal a b = match a, b with
 
 let rec equal_pattern a b =
   a.pat_comment = b.pat_comment &&
-  equal_pattern_kind a.pat_kind b.pat_kind
+  equal_pattern_desc a.pat_desc b.pat_desc
 
-and equal_pattern_kind a b = match a, b with
+and equal_pattern_desc a b = match a, b with
   | PWild,           PWild           -> true
   | PVar x,          PVar y          -> x = y
   | PLit la,         PLit lb         -> equal_literal la lb
@@ -376,9 +376,9 @@ let equal_param a b =
 
 let rec equal_expr a b =
   a.comment = b.comment &&
-  equal_expr_kind a.kind b.kind
+  equal_expr_desc a.desc b.desc
 
-and equal_expr_kind a b = match a, b with
+and equal_expr_desc a b = match a, b with
   | Var x,       Var y       -> x = y
   | IntLit m,    IntLit n    -> m = n
   | FloatLit f,  FloatLit g  -> f = g
@@ -473,11 +473,11 @@ type effect_op = {
 }
 
 type decl = {
-  decl_kind    : decl_kind;
+  decl_desc    : decl_desc;
   decl_comment : string option;
 }
 
-and decl_kind =
+and decl_desc =
   | DeclFn of {
       pub         : bool;
       fn_name     : string;
@@ -507,7 +507,7 @@ and decl_kind =
   | DeclRequire of type_expr
 
 (** Build a declaration node with no comment. *)
-let decl k = { decl_kind = k; decl_comment = None }
+let decl k = { decl_desc = k; decl_comment = None }
 
 type program = decl list
 
@@ -531,12 +531,12 @@ let pp_effect_op fmt { effect_op_name; effect_op_params; effect_op_return } =
     pp_type_expr effect_op_return
 
 let rec pp_decl fmt d =
-  pp_decl_kind fmt d.decl_kind;
+  pp_decl_desc fmt d.decl_desc;
   match d.decl_comment with
   | None   -> ()
   | Some c -> Format.fprintf fmt " @#%s#@" c
 
-and pp_decl_kind fmt = function
+and pp_decl_desc fmt = function
   | DeclFn { pub; fn_name; type_params; params; return_type; effects; decl_body } ->
     Format.fprintf fmt "%sFn %s%s(%a)%s%s { %a }"
       (if pub then "pub " else "")
@@ -589,9 +589,9 @@ let equal_effect_op a b =
 
 let rec equal_decl a b =
   a.decl_comment = b.decl_comment &&
-  equal_decl_kind a.decl_kind b.decl_kind
+  equal_decl_desc a.decl_desc b.decl_desc
 
-and equal_decl_kind a b = match a, b with
+and equal_decl_desc a b = match a, b with
   | DeclFn a, DeclFn b ->
     a.pub = b.pub && a.fn_name = b.fn_name
     && a.type_params = b.type_params

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -39,7 +39,12 @@ type literal =
 (* Patterns                                                             *)
 (* ------------------------------------------------------------------ *)
 
-type pattern =
+type pattern = {
+  pat_kind : pattern_kind;
+  pat_comment : string option;
+}
+
+and pattern_kind =
   | PWild                               (** _ *)
   | PVar    of string                   (** x *)
   | PLit    of literal                  (** 42, true, "s", () *)
@@ -48,11 +53,39 @@ type pattern =
                                         (** { f = p, .. }; bool = is_open *)
   | POr     of pattern * pattern        (** p1 | p2 *)
 
+(** Build a pattern node with no comment. *)
+let pat k = { pat_kind = k; pat_comment = None }
+
 (* ------------------------------------------------------------------ *)
 (* Expression AST (mutually recursive)                                  *)
 (* ------------------------------------------------------------------ *)
 
-type fn_data = {
+type expr = {
+  kind    : expr_kind;
+  comment : string option;
+}
+
+and expr_kind =
+  | Var       of string
+  | IntLit    of int
+  | FloatLit  of float
+  | StringLit of string
+  | BoolLit   of bool
+  | UnitLit
+  | Let       of let_binding
+  | App       of expr * expr list
+  | Fn        of fn_data
+  | Match     of match_data
+  | If        of if_data
+  | Do        of do_stmt list
+  | Letrec    of letrec_binding list * expr
+  | Record    of (string * expr) list
+  | RecordUpdate of expr * (string * expr) list
+  | Project   of expr * string
+  | Perform   of perform_data
+  | Handle    of handle_data
+
+and fn_data = {
   params      : param list;
   return_type : type_expr option;
   effects     : effect_set option;
@@ -92,26 +125,6 @@ and do_stmt =
   | StmtLet  of { pat : pattern; value : expr }
   | StmtExpr of expr
 
-and expr =
-  | Var       of string
-  | IntLit    of int
-  | FloatLit  of float
-  | StringLit of string
-  | BoolLit   of bool
-  | UnitLit
-  | Let       of let_binding
-  | App       of expr * expr list
-  | Fn        of fn_data
-  | Match     of match_data
-  | If        of if_data
-  | Do        of do_stmt list
-  | Letrec    of letrec_binding list * expr
-  | Record    of (string * expr) list
-  | RecordUpdate of expr * (string * expr) list
-  | Project   of expr * string
-  | Perform   of perform_data
-  | Handle    of handle_data
-
 and perform_data = {
   effect_name : string;
   op_name     : string;
@@ -140,6 +153,9 @@ and handle_data = {
   handlers : effect_handler list;
 }
 
+(** Build an expression node with no comment. *)
+let expr k = { kind = k; comment = None }
+
 (* ------------------------------------------------------------------ *)
 (* Pretty-printers                                                      *)
 (* ------------------------------------------------------------------ *)
@@ -151,7 +167,13 @@ let pp_literal fmt = function
   | LBool b   -> Format.fprintf fmt "LBool(%b)" b
   | LUnit     -> Format.pp_print_string fmt "LUnit"
 
-let rec pp_pattern fmt = function
+let rec pp_pattern fmt p =
+  pp_pattern_kind fmt p.pat_kind;
+  match p.pat_comment with
+  | None   -> ()
+  | Some c -> Format.fprintf fmt " @#%s#@" c
+
+and pp_pattern_kind fmt = function
   | PWild        -> Format.pp_print_string fmt "PWild"
   | PVar s       -> Format.fprintf fmt "PVar(%S)" s
   | PLit l       -> Format.fprintf fmt "PLit(%a)" pp_literal l
@@ -195,7 +217,13 @@ and pp_effect_set fmt = function
 let pp_param fmt { param_name; param_type } =
   Format.fprintf fmt "%s: %a" param_name pp_type_expr param_type
 
-let rec pp_expr fmt = function
+let rec pp_expr fmt e =
+  pp_expr_kind fmt e.kind;
+  match e.comment with
+  | None   -> ()
+  | Some c -> Format.fprintf fmt " @#%s#@" c
+
+and pp_expr_kind fmt = function
   | Var s       -> Format.fprintf fmt "Var(%S)" s
   | IntLit n    -> Format.fprintf fmt "IntLit(%d)" n
   | FloatLit f  -> Format.fprintf fmt "FloatLit(%g)" f
@@ -302,7 +330,11 @@ let equal_literal a b = match a, b with
   | LUnit,     LUnit     -> true
   | _,         _         -> false
 
-let rec equal_pattern a b = match a, b with
+let rec equal_pattern a b =
+  a.pat_comment = b.pat_comment &&
+  equal_pattern_kind a.pat_kind b.pat_kind
+
+and equal_pattern_kind a b = match a, b with
   | PWild,           PWild           -> true
   | PVar x,          PVar y          -> x = y
   | PLit la,         PLit lb         -> equal_literal la lb
@@ -342,7 +374,11 @@ and equal_effect_set a b = match a, b with
 let equal_param a b =
   a.param_name = b.param_name && equal_type_expr a.param_type b.param_type
 
-let rec equal_expr a b = match a, b with
+let rec equal_expr a b =
+  a.comment = b.comment &&
+  equal_expr_kind a.kind b.kind
+
+and equal_expr_kind a b = match a, b with
   | Var x,       Var y       -> x = y
   | IntLit m,    IntLit n    -> m = n
   | FloatLit f,  FloatLit g  -> f = g
@@ -436,7 +472,12 @@ type effect_op = {
   effect_op_return : type_expr;
 }
 
-type decl =
+type decl = {
+  decl_kind    : decl_kind;
+  decl_comment : string option;
+}
+
+and decl_kind =
   | DeclFn of {
       pub         : bool;
       fn_name     : string;
@@ -465,6 +506,9 @@ type decl =
     }
   | DeclRequire of type_expr
 
+(** Build a declaration node with no comment. *)
+let decl k = { decl_kind = k; decl_comment = None }
+
 type program = decl list
 
 (* ------------------------------------------------------------------ *)
@@ -486,7 +530,13 @@ let pp_effect_op fmt { effect_op_name; effect_op_params; effect_op_return } =
        pp_type_expr) effect_op_params
     pp_type_expr effect_op_return
 
-let rec pp_decl fmt = function
+let rec pp_decl fmt d =
+  pp_decl_kind fmt d.decl_kind;
+  match d.decl_comment with
+  | None   -> ()
+  | Some c -> Format.fprintf fmt " @#%s#@" c
+
+and pp_decl_kind fmt = function
   | DeclFn { pub; fn_name; type_params; params; return_type; effects; decl_body } ->
     Format.fprintf fmt "%sFn %s%s(%a)%s%s { %a }"
       (if pub then "pub " else "")
@@ -537,7 +587,11 @@ let equal_effect_op a b =
   && List.for_all2 equal_type_expr a.effect_op_params b.effect_op_params
   && equal_type_expr a.effect_op_return b.effect_op_return
 
-let rec equal_decl a b = match a, b with
+let rec equal_decl a b =
+  a.decl_comment = b.decl_comment &&
+  equal_decl_kind a.decl_kind b.decl_kind
+
+and equal_decl_kind a b = match a, b with
   | DeclFn a, DeclFn b ->
     a.pub = b.pub && a.fn_name = b.fn_name
     && a.type_params = b.type_params

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -41,6 +41,8 @@ type token =
   | Plus | Minus | Star | Slash | Percent
   | EqEq       (** == *)
   | BangEq     (** != *)
+  (* Comments *)
+  | Comment of string  (** @# ... #@ — node-attached comment *)
 
 (* ------------------------------------------------------------------ *)
 (* Pretty-printer and equality (used by tests via Alcotest)            *)
@@ -97,6 +99,7 @@ let pp_token fmt = function
   | Percent  -> Format.pp_print_string fmt "Percent"
   | EqEq     -> Format.pp_print_string fmt "EqEq"
   | BangEq   -> Format.pp_print_string fmt "BangEq"
+  | Comment s -> Format.fprintf fmt "Comment(%S)" s
 
 let equal_token a b = a = b
 
@@ -238,6 +241,27 @@ let scan_string st =
 let skip_line_comment st =
   while st.pos < st.len && st.src.[st.pos] <> '\n' do advance st done
 
+(** Scan a node-attached comment opened by '@#'.
+    Reads everything until the closing '#@' delimiter. *)
+let scan_comment st =
+  let buf = Buffer.create 64 in
+  let rec loop () =
+    if st.pos >= st.len then
+      failwith "Unterminated comment (expected #@)"
+    else if st.src.[st.pos] = '#'
+         && st.pos + 1 < st.len
+         && st.src.[st.pos + 1] = '@' then begin
+      advance st; advance st   (* consume '#@' *)
+    end else begin
+      Buffer.add_char buf st.src.[st.pos];
+      advance st;
+      loop ()
+    end
+  in
+  loop ();
+  let raw = Buffer.contents buf in
+  Comment (String.trim raw)
+
 (* ------------------------------------------------------------------ *)
 (* Main tokenizer                                                       *)
 (* ------------------------------------------------------------------ *)
@@ -308,6 +332,10 @@ let tokenize (src : string) : token list =
     | Some '*' -> advance st; push Star;    loop ()
     | Some '/' -> advance st; push Slash;   loop ()
     | Some '%' -> advance st; push Percent; loop ()
+
+    (* Node-attached comments: @# ... #@ *)
+    | Some '@' when peek2 st = Some '#' ->
+      advance st; advance st; push (scan_comment st); loop ()
 
     (* Skip unknown characters *)
     | Some _ -> advance st; loop ()

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -28,6 +28,28 @@ let consume st expected =
                 pp_token expected)
 
 (* ------------------------------------------------------------------ *)
+(* Comment attachment helpers                                           *)
+(* ------------------------------------------------------------------ *)
+
+(** If the next token is a Comment, consume it and attach to the expr. *)
+let maybe_comment_expr st (e : Ast.expr) : Ast.expr =
+  match peek st with
+  | Some (Comment c) -> advance st; { e with comment = Some c }
+  | _ -> e
+
+(** If the next token is a Comment, consume it and attach to the pattern. *)
+let maybe_comment_pat st (p : Ast.pattern) : Ast.pattern =
+  match peek st with
+  | Some (Comment c) -> advance st; { p with pat_comment = Some c }
+  | _ -> p
+
+(** If the next token is a Comment, consume it and attach to the decl. *)
+let maybe_comment_decl st (d : Ast.decl) : Ast.decl =
+  match peek st with
+  | Some (Comment c) -> advance st; { d with decl_comment = Some c }
+  | _ -> d
+
+(* ------------------------------------------------------------------ *)
 (* Type expression, effect set, and param parsers (mutually recursive) *)
 (* ------------------------------------------------------------------ *)
 
@@ -130,53 +152,55 @@ and parse_params_rest (st : state) : param list =
 (* parse_pattern parses a single atomic pattern (no or-pattern at top level).
    Use parse_pattern_or in contexts that accept | inside a pattern. *)
 let rec parse_pattern (st : state) : pattern =
-  match peek st with
-  | Some (Ident "_")   -> advance st; Ast.PWild
-  | Some (Ident s)     -> advance st; Ast.PVar s
-  | Some (CtorIdent s) ->
-    advance st;
-    let sub_pats = match peek st with
-      | Some LParen ->
-        advance st;
-        (match peek st with
-         | Some RParen -> advance st; []
-         | _ ->
-           let first = parse_pattern_or st in
-           let rest  = parse_pat_args_rest st in
-           consume st RParen;
-           first :: rest)
-      | _ -> []
-    in
-    Ast.PCtor (s, sub_pats)
-  | Some (IntLit n)    -> advance st; Ast.PLit (LInt n)
-  | Some (FloatLit f)  -> advance st; Ast.PLit (LFloat f)
-  | Some (StringLit s) -> advance st; Ast.PLit (LString s)
-  | Some True          -> advance st; Ast.PLit (LBool true)
-  | Some False         -> advance st; Ast.PLit (LBool false)
-  | Some LParen ->
-    (match st.tokens with
-     | _ :: RParen :: _ -> advance st; advance st; Ast.PLit LUnit
-     | _ :: _ ->
-       (* Parenthesised pattern *)
-       advance st;
-       let p = parse_pattern_or st in
-       consume st RParen;
-       p
-     | _ -> failwith "Parser: unexpected '(' in pattern")
-  | Some LBrace ->
-    (* Record pattern: { f = p, g, .. } *)
-    advance st;
-    let (fields, open_) = parse_record_pat_fields st in
-    consume st RBrace;
-    Ast.PRecord (fields, open_)
-  | Some t ->
-    failwith (Format.asprintf "Parser: unexpected token in pattern: %a" pp_token t)
-  | None -> failwith "Parser: unexpected end of input in pattern"
+  let p = match peek st with
+    | Some (Ident "_")   -> advance st; Ast.pat PWild
+    | Some (Ident s)     -> advance st; Ast.pat (PVar s)
+    | Some (CtorIdent s) ->
+      advance st;
+      let sub_pats = match peek st with
+        | Some LParen ->
+          advance st;
+          (match peek st with
+           | Some RParen -> advance st; []
+           | _ ->
+             let first = parse_pattern_or st in
+             let rest  = parse_pat_args_rest st in
+             consume st RParen;
+             first :: rest)
+        | _ -> []
+      in
+      Ast.pat (PCtor (s, sub_pats))
+    | Some (IntLit n)    -> advance st; Ast.pat (PLit (LInt n))
+    | Some (FloatLit f)  -> advance st; Ast.pat (PLit (LFloat f))
+    | Some (StringLit s) -> advance st; Ast.pat (PLit (LString s))
+    | Some True          -> advance st; Ast.pat (PLit (LBool true))
+    | Some False         -> advance st; Ast.pat (PLit (LBool false))
+    | Some LParen ->
+      (match st.tokens with
+       | _ :: RParen :: _ -> advance st; advance st; Ast.pat (PLit LUnit)
+       | _ :: _ ->
+         (* Parenthesised pattern *)
+         advance st;
+         let p = parse_pattern_or st in
+         consume st RParen;
+         p
+       | _ -> failwith "Parser: unexpected '(' in pattern")
+    | Some LBrace ->
+      (* Record pattern: { f = p, g, .. } *)
+      advance st;
+      let (fields, open_) = parse_record_pat_fields st in
+      consume st RBrace;
+      Ast.pat (PRecord (fields, open_))
+    | Some t ->
+      failwith (Format.asprintf "Parser: unexpected token in pattern: %a" pp_token t)
+    | None -> failwith "Parser: unexpected end of input in pattern"
+  in
+  maybe_comment_pat st p
 
 and parse_pattern_or (st : state) : pattern =
   let p = parse_pattern st in
   match peek st with
-  | Some Pipe -> advance st; Ast.POr (p, parse_pattern_or st)
+  | Some Pipe -> advance st; Ast.pat (POr (p, parse_pattern_or st))
   | _ -> p
 
 and parse_pat_args_rest (st : state) : pattern list =
@@ -192,7 +216,7 @@ and parse_record_pat_fields (st : state) : (string * pattern) list * bool =
     advance st;
     let pat = match peek st with
       | Some Equal -> advance st; parse_pattern_or st
-      | _          -> Ast.PVar field   (* shorthand: field name as variable *)
+      | _          -> Ast.pat (PVar field)   (* shorthand: field name as variable *)
     in
     (match peek st with
      | Some Comma ->
@@ -340,7 +364,7 @@ and parse_expr_state (st : state) : expr =
     consume st RBrace;
     consume st In;
     let body = parse_expr_state st in
-    Ast.Letrec (first :: rest, body)
+    Ast.expr (Letrec (first :: rest, body))
 
   | Some Let ->
     advance st;
@@ -349,7 +373,7 @@ and parse_expr_state (st : state) : expr =
     let value = parse_expr_state st in
     consume st In;
     let body = parse_expr_state st in
-    Ast.Let { pat; value; body }
+    Ast.expr (Let { pat; value; body })
 
   | Some Handle ->
     advance st;
@@ -358,7 +382,7 @@ and parse_expr_state (st : state) : expr =
     consume st LBrace;
     let handlers = parse_effect_handlers st in
     consume st RBrace;
-    Ast.Handle { handled; handlers }
+    Ast.expr (Handle { handled; handlers })
 
   | Some Perform ->
     advance st;
@@ -379,14 +403,14 @@ and parse_expr_state (st : state) : expr =
     consume st LParen;
     let args = parse_args st in
     consume st RParen;
-    Ast.Perform { effect_name; op_name; args }
+    Ast.expr (Perform { effect_name; op_name; args })
 
   | Some Do ->
     advance st;
     consume st LBrace;
     let stmts = parse_do_stmts st in
     consume st RBrace;
-    Ast.Do stmts
+    Ast.expr (Do stmts)
 
   | Some If ->
     advance st;
@@ -398,7 +422,7 @@ and parse_expr_state (st : state) : expr =
     consume st LBrace;
     let else_ = parse_expr_state st in
     consume st RBrace;
-    Ast.If { cond; then_; else_ }
+    Ast.expr (If { cond; then_; else_ })
 
   | Some Match ->
     advance st;
@@ -407,7 +431,7 @@ and parse_expr_state (st : state) : expr =
     consume st LBrace;
     let arms = parse_match_arms st in
     consume st RBrace;
-    Ast.Match { scrutinee; arms }
+    Ast.expr (Match { scrutinee; arms })
 
   | Some Fn ->
     advance st;
@@ -427,7 +451,7 @@ and parse_expr_state (st : state) : expr =
     consume st LBrace;
     let fn_body = parse_expr_state st in
     consume st RBrace;
-    Ast.Fn { params; return_type; effects; fn_body }
+    Ast.expr (Fn { params; return_type; effects; fn_body })
 
   | _ ->
     parse_app st
@@ -442,12 +466,16 @@ and parse_app_rest (st : state) (f : expr) : expr =
     advance st;
     let args = parse_args st in
     consume st RParen;
-    parse_app_rest st (Ast.App (f, args))
+    let e = Ast.expr (App (f, args)) in
+    let e = maybe_comment_expr st e in
+    parse_app_rest st e
   | Some Dot ->
     (match st.tokens with
      | _ :: Ident field :: _ ->
        advance st; advance st;
-       parse_app_rest st (Ast.Project (f, field))
+       let e = Ast.expr (Project (f, field)) in
+       let e = maybe_comment_expr st e in
+       parse_app_rest st e
      | _ -> f)
   | _ -> f
 
@@ -469,39 +497,46 @@ and parse_record_fields (st : state) : (string * expr) list =
   | None -> failwith "Parser: expected field name in record, got end of input"
 
 and parse_atom (st : state) : expr =
-  match peek st with
-  | Some (IntLit n)    -> advance st; Ast.IntLit n
-  | Some (FloatLit f)  -> advance st; Ast.FloatLit f
-  | Some (StringLit s) -> advance st; Ast.StringLit s
-  | Some True          -> advance st; Ast.BoolLit true
-  | Some False         -> advance st; Ast.BoolLit false
-  | Some (Ident s)     -> advance st; Ast.Var s
-  | Some Resume        -> advance st; Ast.Var "resume"
-  | Some LBrace ->
-    (* { } empty record; { ident : ... } record literal; { expr with ... } update *)
-    (match st.tokens with
-     | _ :: RBrace :: _ ->
-       advance st; advance st; Ast.Record []
-     | _ :: Ident _ :: Colon :: _ ->
-       advance st;
-       let fields = parse_record_fields st in
-       consume st RBrace;
-       Ast.Record fields
-     | _ ->
-       advance st;
-       let base = parse_expr_state st in
-       consume st With;
-       let fields = parse_record_fields st in
-       consume st RBrace;
-       Ast.RecordUpdate (base, fields))
-  | Some LParen ->
-    (match st.tokens with
-     | _ :: RParen :: _ -> advance st; advance st; Ast.UnitLit
-     | _ -> failwith "Parser: unexpected '(' (use do-block for sequencing)")
-  | Some t ->
-    failwith (Format.asprintf "Parser: unexpected token %a" pp_token t)
-  | None ->
-    failwith "Parser: unexpected end of input"
+  let e = match peek st with
+    | Some (IntLit n)    -> advance st; Ast.expr (IntLit n)
+    | Some (FloatLit f)  -> advance st; Ast.expr (FloatLit f)
+    | Some (StringLit s) -> advance st; Ast.expr (StringLit s)
+    | Some True          -> advance st; Ast.expr (BoolLit true)
+    | Some False         -> advance st; Ast.expr (BoolLit false)
+    | Some (Ident s)     -> advance st; Ast.expr (Var s)
+    | Some Resume        -> advance st; Ast.expr (Var "resume")
+    | Some LBrace ->
+      (* { } empty record; { ident : ... } record literal; { expr with ... } update *)
+      (match st.tokens with
+       | _ :: RBrace :: _ ->
+         advance st; advance st; Ast.expr (Record [])
+       | _ :: Ident _ :: Colon :: _ ->
+         advance st;
+         let fields = parse_record_fields st in
+         consume st RBrace;
+         Ast.expr (Record fields)
+       | _ ->
+         advance st;
+         let base = parse_expr_state st in
+         consume st With;
+         let fields = parse_record_fields st in
+         consume st RBrace;
+         Ast.expr (RecordUpdate (base, fields)))
+    | Some LParen ->
+      (match st.tokens with
+       | _ :: RParen :: _ -> advance st; advance st; Ast.expr UnitLit
+       | _ ->
+         (* Parenthesised expression for grouping *)
+         advance st;
+         let inner = parse_expr_state st in
+         consume st RParen;
+         inner)
+    | Some t ->
+      failwith (Format.asprintf "Parser: unexpected token %a" pp_token t)
+    | None ->
+      failwith "Parser: unexpected end of input"
+  in
+  maybe_comment_expr st e
 
 (* ------------------------------------------------------------------ *)
 (* Public entry point — expressions                                     *)
@@ -601,92 +636,94 @@ let rec parse_decl (st : state) : Ast.decl =
     | Some Pub -> advance st; true
     | _        -> false
   in
-  match peek st with
-  | Some Fn ->
-    advance st;
-    let fn_name = match peek st with
-      | Some (Ident s) -> advance st; s
-      | Some t ->
-        failwith (Format.asprintf "Parser: expected fn name, got %a" pp_token t)
-      | None -> failwith "Parser: expected fn name"
-    in
-    let type_params = parse_type_params st in
-    consume st LParen;
-    let params = parse_params st in
-    consume st RParen;
-    let (return_type, effects) =
-      match peek st with
-      | Some Arrow ->
-        advance st;
-        let ret = parse_type_expr st in
-        consume st Bang;
-        let eff = parse_effect_set st in
-        (Some ret, Some eff)
-      | _ -> (None, None)
-    in
-    consume st LBrace;
-    let decl_body = parse_expr_state st in
-    consume st RBrace;
-    Ast.DeclFn { pub; fn_name; type_params; params; return_type; effects; decl_body }
+  let d = match peek st with
+    | Some Fn ->
+      advance st;
+      let fn_name = match peek st with
+        | Some (Ident s) -> advance st; s
+        | Some t ->
+          failwith (Format.asprintf "Parser: expected fn name, got %a" pp_token t)
+        | None -> failwith "Parser: expected fn name"
+      in
+      let type_params = parse_type_params st in
+      consume st LParen;
+      let params = parse_params st in
+      consume st RParen;
+      let (return_type, effects) =
+        match peek st with
+        | Some Arrow ->
+          advance st;
+          let ret = parse_type_expr st in
+          consume st Bang;
+          let eff = parse_effect_set st in
+          (Some ret, Some eff)
+        | _ -> (None, None)
+      in
+      consume st LBrace;
+      let decl_body = parse_expr_state st in
+      consume st RBrace;
+      Ast.decl (DeclFn { pub; fn_name; type_params; params; return_type; effects; decl_body })
 
-  | Some Type ->
-    advance st;
-    let type_name = match peek st with
-      | Some (CtorIdent s) -> advance st; s
-      | Some t ->
-        failwith (Format.asprintf "Parser: expected type name, got %a" pp_token t)
-      | None -> failwith "Parser: expected type name"
-    in
-    let type_params = parse_type_params st in
-    consume st Equal;
-    consume st Pipe;
-    let first = parse_ctor_decl st in
-    let rest  = parse_ctor_decls_rest st in
-    Ast.DeclType { pub; type_name; type_params; ctors = first :: rest }
+    | Some Type ->
+      advance st;
+      let type_name = match peek st with
+        | Some (CtorIdent s) -> advance st; s
+        | Some t ->
+          failwith (Format.asprintf "Parser: expected type name, got %a" pp_token t)
+        | None -> failwith "Parser: expected type name"
+      in
+      let type_params = parse_type_params st in
+      consume st Equal;
+      consume st Pipe;
+      let first = parse_ctor_decl st in
+      let rest  = parse_ctor_decls_rest st in
+      Ast.decl (DeclType { pub; type_name; type_params; ctors = first :: rest })
 
-  | Some Effect ->
-    advance st;
-    let effect_name = match peek st with
-      | Some (CtorIdent s) -> advance st; s
-      | Some t ->
-        failwith (Format.asprintf "Parser: expected effect name, got %a" pp_token t)
-      | None -> failwith "Parser: expected effect name"
-    in
-    let type_params = parse_type_params st in
-    consume st LBrace;
-    let ops = match peek st with
-      | Some RBrace -> []
-      | _ ->
-        let first = parse_effect_op_decl st in
-        let rest  = parse_effect_ops_rest st in
-        first :: rest
-    in
-    consume st RBrace;
-    Ast.DeclEffect { pub; effect_name; type_params; ops }
+    | Some Effect ->
+      advance st;
+      let effect_name = match peek st with
+        | Some (CtorIdent s) -> advance st; s
+        | Some t ->
+          failwith (Format.asprintf "Parser: expected effect name, got %a" pp_token t)
+        | None -> failwith "Parser: expected effect name"
+      in
+      let type_params = parse_type_params st in
+      consume st LBrace;
+      let ops = match peek st with
+        | Some RBrace -> []
+        | _ ->
+          let first = parse_effect_op_decl st in
+          let rest  = parse_effect_ops_rest st in
+          first :: rest
+      in
+      consume st RBrace;
+      Ast.decl (DeclEffect { pub; effect_name; type_params; ops })
 
-  | Some Module ->
-    advance st;
-    let module_name = match peek st with
-      | Some (Ident s) -> advance st; s
-      | Some t ->
-        failwith (Format.asprintf "Parser: expected module name, got %a" pp_token t)
-      | None -> failwith "Parser: expected module name"
-    in
-    consume st LBrace;
-    let body = parse_decls_until_rbrace st in
-    consume st RBrace;
-    Ast.DeclModule { pub; module_name; body }
+    | Some Module ->
+      advance st;
+      let module_name = match peek st with
+        | Some (Ident s) -> advance st; s
+        | Some t ->
+          failwith (Format.asprintf "Parser: expected module name, got %a" pp_token t)
+        | None -> failwith "Parser: expected module name"
+      in
+      consume st LBrace;
+      let body = parse_decls_until_rbrace st in
+      consume st RBrace;
+      Ast.decl (DeclModule { pub; module_name; body })
 
-  | Some Require ->
-    advance st;
-    consume st Effect;    (* require effect T — the 'effect' keyword is mandatory *)
-    let t = parse_type_expr st in
-    Ast.DeclRequire t
+    | Some Require ->
+      advance st;
+      consume st Effect;    (* require effect T — the 'effect' keyword is mandatory *)
+      let t = parse_type_expr st in
+      Ast.decl (DeclRequire t)
 
-  | Some t ->
-    failwith (Format.asprintf "Parser: expected declaration, got %a" pp_token t)
-  | None ->
-    failwith "Parser: expected declaration, got end of input"
+    | Some t ->
+      failwith (Format.asprintf "Parser: expected declaration, got %a" pp_token t)
+    | None ->
+      failwith "Parser: expected declaration, got end of input"
+  in
+  maybe_comment_decl st d
 
 and parse_decls_until_rbrace (st : state) : Ast.decl list =
   match peek st with

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -218,7 +218,7 @@ let rec ty_of_type_expr = function
 (** [infer_expr env e] infers the type of expression [e] under [env].
     Returns the inferred type. Raises [Failure] on type errors. *)
 let rec infer_expr (env : env) (e : expr) : ty =
-  match e.kind with
+  match e.desc with
 
   | IntLit _    -> TyCon "Int"
   | FloatLit _  -> TyCon "Float64"
@@ -233,7 +233,7 @@ let rec infer_expr (env : env) (e : expr) : ty =
   | Let { pat; value; body } ->
     let ty_val = infer_expr env value in
     let scheme = generalize env ty_val in
-    let env'   = match pat.pat_kind with
+    let env'   = match pat.pat_desc with
       | PVar name -> env_extend name scheme env
       | _         -> env_from_pattern env pat ty_val
     in
@@ -351,7 +351,7 @@ let rec infer_expr (env : env) (e : expr) : ty =
       | StmtExpr e :: rest         -> ignore (infer_expr env e); go env rest
       | StmtLet { pat; value } :: rest ->
         let ty   = infer_expr env value in
-        let env' = match pat.pat_kind with
+        let env' = match pat.pat_desc with
           | PVar name -> env_extend name (generalize env ty) env
           | _         -> env_from_pattern env pat ty
         in
@@ -369,7 +369,7 @@ let rec infer_expr (env : env) (e : expr) : ty =
 (** Extend environment with bindings introduced by a pattern.
     Currently handles PWild and PVar; constructor patterns don't bind new scrutinee types. *)
 and env_from_pattern env (p : pattern) scrut_ty =
-  match p.pat_kind with
+  match p.pat_desc with
   | PWild         -> env
   | PVar x        -> env_extend x (mono scrut_ty) env
   | PLit _        -> env

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -218,7 +218,7 @@ let rec ty_of_type_expr = function
 (** [infer_expr env e] infers the type of expression [e] under [env].
     Returns the inferred type. Raises [Failure] on type errors. *)
 let rec infer_expr (env : env) (e : expr) : ty =
-  match e with
+  match e.kind with
 
   | IntLit _    -> TyCon "Int"
   | FloatLit _  -> TyCon "Float64"
@@ -233,7 +233,7 @@ let rec infer_expr (env : env) (e : expr) : ty =
   | Let { pat; value; body } ->
     let ty_val = infer_expr env value in
     let scheme = generalize env ty_val in
-    let env'   = match pat with
+    let env'   = match pat.pat_kind with
       | PVar name -> env_extend name scheme env
       | _         -> env_from_pattern env pat ty_val
     in
@@ -351,7 +351,7 @@ let rec infer_expr (env : env) (e : expr) : ty =
       | StmtExpr e :: rest         -> ignore (infer_expr env e); go env rest
       | StmtLet { pat; value } :: rest ->
         let ty   = infer_expr env value in
-        let env' = match pat with
+        let env' = match pat.pat_kind with
           | PVar name -> env_extend name (generalize env ty) env
           | _         -> env_from_pattern env pat ty
         in
@@ -368,8 +368,8 @@ let rec infer_expr (env : env) (e : expr) : ty =
 
 (** Extend environment with bindings introduced by a pattern.
     Currently handles PWild and PVar; constructor patterns don't bind new scrutinee types. *)
-and env_from_pattern env pat scrut_ty =
-  match pat with
+and env_from_pattern env (p : pattern) scrut_ty =
+  match p.pat_kind with
   | PWild         -> env
   | PVar x        -> env_extend x (mono scrut_ty) env
   | PLit _        -> env

--- a/test/test_decl_parser.ml
+++ b/test/test_decl_parser.ml
@@ -26,12 +26,6 @@ let check_decl label src expected =
 let check_prog label src expected =
   Alcotest.(check program_testable) label expected (parse_prog_of src)
 
-(** Shorthand: build an expression node with no comment. *)
-let e k = expr k
-
-(** Shorthand: build a declaration node with no comment. *)
-let d k = decl k
-
 (* ------------------------------------------------------------------ *)
 (* fn declarations                                                      *)
 (* ------------------------------------------------------------------ *)
@@ -40,50 +34,50 @@ let d k = decl k
 let test_fn_decl_simple () =
   check_decl "fn simple"
     "fn identity(x: Int) -> Int ! pure { x }"
-    (d (DeclFn { pub         = false
+    (decl (DeclFn { pub         = false
                ; fn_name     = "identity"
                ; type_params = []
                ; params      = [{ param_name = "x"; param_type = TyName "Int" }]
                ; return_type = Some (TyName "Int")
                ; effects     = Some Pure
-               ; decl_body   = e (Var "x") }))
+               ; decl_body   = expr (Var "x") }))
 
 (* pub fn add(x: Int, y: Int) -> Int ! pure { x } *)
 let test_fn_decl_pub () =
   check_decl "fn pub"
     "pub fn add(x: Int, y: Int) -> Int ! pure { x }"
-    (d (DeclFn { pub         = true
+    (decl (DeclFn { pub         = true
                ; fn_name     = "add"
                ; type_params = []
                ; params      = [ { param_name = "x"; param_type = TyName "Int" }
                                 ; { param_name = "y"; param_type = TyName "Int" } ]
                ; return_type = Some (TyName "Int")
                ; effects     = Some Pure
-               ; decl_body   = e (Var "x") }))
+               ; decl_body   = expr (Var "x") }))
 
 (* fn id<a>(x: a) -> a ! pure { x } -- type params *)
 let test_fn_decl_type_params () =
   check_decl "fn type params"
     "fn id<a>(x: a) -> a ! pure { x }"
-    (d (DeclFn { pub         = false
+    (decl (DeclFn { pub         = false
                ; fn_name     = "id"
                ; type_params = ["a"]
                ; params      = [{ param_name = "x"; param_type = TyName "a" }]
                ; return_type = Some (TyName "a")
                ; effects     = Some Pure
-               ; decl_body   = e (Var "x") }))
+               ; decl_body   = expr (Var "x") }))
 
 (* fn noop() { () } -- no return type annotation *)
 let test_fn_decl_no_annotation () =
   check_decl "fn no annotation"
     "fn noop() { () }"
-    (d (DeclFn { pub         = false
+    (decl (DeclFn { pub         = false
                ; fn_name     = "noop"
                ; type_params = []
                ; params      = []
                ; return_type = None
                ; effects     = None
-               ; decl_body   = e UnitLit }))
+               ; decl_body   = expr UnitLit }))
 
 (* ------------------------------------------------------------------ *)
 (* type declarations                                                    *)
@@ -93,7 +87,7 @@ let test_fn_decl_no_annotation () =
 let test_type_decl_option () =
   check_decl "type Option"
     "type Option<a> = | None | Some(a)"
-    (d (DeclType { pub         = false
+    (decl (DeclType { pub         = false
                  ; type_name   = "Option"
                  ; type_params = ["a"]
                  ; ctors       = [ { ctor_name = "None"; ctor_params = [] }
@@ -103,7 +97,7 @@ let test_type_decl_option () =
 let test_type_decl_bool () =
   check_decl "type Bool"
     "type Bool = | True | False"
-    (d (DeclType { pub         = false
+    (decl (DeclType { pub         = false
                  ; type_name   = "Bool"
                  ; type_params = []
                  ; ctors       = [ { ctor_name = "True";  ctor_params = [] }
@@ -113,7 +107,7 @@ let test_type_decl_bool () =
 let test_type_decl_result () =
   check_decl "type Result"
     "pub type Result<a, e> = | Ok(a) | Err(e)"
-    (d (DeclType { pub         = true
+    (decl (DeclType { pub         = true
                  ; type_name   = "Result"
                  ; type_params = ["a"; "e"]
                  ; ctors       = [ { ctor_name = "Ok";  ctor_params = [TyName "a"] }
@@ -127,7 +121,7 @@ let test_type_decl_result () =
 let test_effect_decl_state () =
   check_decl "effect State"
     "effect State<s> { get: () -> s, put: (s) -> Unit }"
-    (d (DeclEffect { pub         = false
+    (decl (DeclEffect { pub         = false
                    ; effect_name = "State"
                    ; type_params = ["s"]
                    ; ops         = [ { effect_op_name   = "get"
@@ -141,7 +135,7 @@ let test_effect_decl_state () =
 let test_effect_decl_log () =
   check_decl "effect Log"
     "effect Log { log: (String) -> Unit }"
-    (d (DeclEffect { pub         = false
+    (decl (DeclEffect { pub         = false
                    ; effect_name = "Log"
                    ; type_params = []
                    ; ops         = [ { effect_op_name   = "log"
@@ -156,16 +150,16 @@ let test_effect_decl_log () =
 let test_module_decl () =
   check_decl "module"
     "module math { fn square(x: Int) { x } }"
-    (d (DeclModule { pub         = false
+    (decl (DeclModule { pub         = false
                    ; module_name = "math"
                    ; body        =
-                       [ d (DeclFn { pub         = false
+                       [ decl (DeclFn { pub         = false
                                    ; fn_name     = "square"
                                    ; type_params = []
                                    ; params      = [{ param_name = "x"; param_type = TyName "Int" }]
                                    ; return_type = None
                                    ; effects     = None
-                                   ; decl_body   = e (Var "x") }) ] }))
+                                   ; decl_body   = expr (Var "x") }) ] }))
 
 (* ------------------------------------------------------------------ *)
 (* require declarations                                                 *)
@@ -175,7 +169,7 @@ let test_module_decl () =
 let test_require_decl () =
   check_decl "require"
     "require effect Log"
-    (d (DeclRequire (TyName "Log")))
+    (decl (DeclRequire (TyName "Log")))
 
 (* ------------------------------------------------------------------ *)
 (* Multi-declaration programs                                           *)
@@ -185,12 +179,12 @@ let test_require_decl () =
 let test_program_two_fns () =
   check_prog "two fns"
     "fn foo(x: Int) { x }  fn bar(y: Bool) { y }"
-    [ d (DeclFn { pub = false; fn_name = "foo"; type_params = []
+    [ decl (DeclFn { pub = false; fn_name = "foo"; type_params = []
                 ; params = [{ param_name = "x"; param_type = TyName "Int" }]
-                ; return_type = None; effects = None; decl_body = e (Var "x") })
-    ; d (DeclFn { pub = false; fn_name = "bar"; type_params = []
+                ; return_type = None; effects = None; decl_body = expr (Var "x") })
+    ; decl (DeclFn { pub = false; fn_name = "bar"; type_params = []
                 ; params = [{ param_name = "y"; param_type = TyName "Bool" }]
-                ; return_type = None; effects = None; decl_body = e (Var "y") }) ]
+                ; return_type = None; effects = None; decl_body = expr (Var "y") }) ]
 
 (* ------------------------------------------------------------------ *)
 (* Comment attachment on declarations                                   *)
@@ -202,7 +196,7 @@ let test_fn_decl_comment () =
     "fn foo(x: Int) { x } @# entry point #@"
     { decl_desc = DeclFn { pub = false; fn_name = "foo"; type_params = []
                           ; params = [{ param_name = "x"; param_type = TyName "Int" }]
-                          ; return_type = None; effects = None; decl_body = e (Var "x") }
+                          ; return_type = None; effects = None; decl_body = expr (Var "x") }
     ; decl_comment = Some "entry point" }
 
 (* type Bool = | True | False @# boolean type #@ *)

--- a/test/test_decl_parser.ml
+++ b/test/test_decl_parser.ml
@@ -200,7 +200,7 @@ let test_program_two_fns () =
 let test_fn_decl_comment () =
   check_decl "fn with comment"
     "fn foo(x: Int) { x } @# entry point #@"
-    { decl_kind = DeclFn { pub = false; fn_name = "foo"; type_params = []
+    { decl_desc = DeclFn { pub = false; fn_name = "foo"; type_params = []
                           ; params = [{ param_name = "x"; param_type = TyName "Int" }]
                           ; return_type = None; effects = None; decl_body = e (Var "x") }
     ; decl_comment = Some "entry point" }
@@ -209,7 +209,7 @@ let test_fn_decl_comment () =
 let test_type_decl_comment () =
   check_decl "type with comment"
     "type Bool = | True | False @# boolean type #@"
-    { decl_kind = DeclType { pub = false; type_name = "Bool"; type_params = []
+    { decl_desc = DeclType { pub = false; type_name = "Bool"; type_params = []
                             ; ctors = [ { ctor_name = "True"; ctor_params = [] }
                                        ; { ctor_name = "False"; ctor_params = [] } ] }
     ; decl_comment = Some "boolean type" }

--- a/test/test_decl_parser.ml
+++ b/test/test_decl_parser.ml
@@ -26,6 +26,12 @@ let check_decl label src expected =
 let check_prog label src expected =
   Alcotest.(check program_testable) label expected (parse_prog_of src)
 
+(** Shorthand: build an expression node with no comment. *)
+let e k = expr k
+
+(** Shorthand: build a declaration node with no comment. *)
+let d k = decl k
+
 (* ------------------------------------------------------------------ *)
 (* fn declarations                                                      *)
 (* ------------------------------------------------------------------ *)
@@ -34,50 +40,50 @@ let check_prog label src expected =
 let test_fn_decl_simple () =
   check_decl "fn simple"
     "fn identity(x: Int) -> Int ! pure { x }"
-    (DeclFn { pub         = false
-            ; fn_name     = "identity"
-            ; type_params = []
-            ; params      = [{ param_name = "x"; param_type = TyName "Int" }]
-            ; return_type = Some (TyName "Int")
-            ; effects     = Some Pure
-            ; decl_body   = Var "x" })
+    (d (DeclFn { pub         = false
+               ; fn_name     = "identity"
+               ; type_params = []
+               ; params      = [{ param_name = "x"; param_type = TyName "Int" }]
+               ; return_type = Some (TyName "Int")
+               ; effects     = Some Pure
+               ; decl_body   = e (Var "x") }))
 
 (* pub fn add(x: Int, y: Int) -> Int ! pure { x } *)
 let test_fn_decl_pub () =
   check_decl "fn pub"
     "pub fn add(x: Int, y: Int) -> Int ! pure { x }"
-    (DeclFn { pub         = true
-            ; fn_name     = "add"
-            ; type_params = []
-            ; params      = [ { param_name = "x"; param_type = TyName "Int" }
-                             ; { param_name = "y"; param_type = TyName "Int" } ]
-            ; return_type = Some (TyName "Int")
-            ; effects     = Some Pure
-            ; decl_body   = Var "x" })
+    (d (DeclFn { pub         = true
+               ; fn_name     = "add"
+               ; type_params = []
+               ; params      = [ { param_name = "x"; param_type = TyName "Int" }
+                                ; { param_name = "y"; param_type = TyName "Int" } ]
+               ; return_type = Some (TyName "Int")
+               ; effects     = Some Pure
+               ; decl_body   = e (Var "x") }))
 
 (* fn id<a>(x: a) -> a ! pure { x } -- type params *)
 let test_fn_decl_type_params () =
   check_decl "fn type params"
     "fn id<a>(x: a) -> a ! pure { x }"
-    (DeclFn { pub         = false
-            ; fn_name     = "id"
-            ; type_params = ["a"]
-            ; params      = [{ param_name = "x"; param_type = TyName "a" }]
-            ; return_type = Some (TyName "a")
-            ; effects     = Some Pure
-            ; decl_body   = Var "x" })
+    (d (DeclFn { pub         = false
+               ; fn_name     = "id"
+               ; type_params = ["a"]
+               ; params      = [{ param_name = "x"; param_type = TyName "a" }]
+               ; return_type = Some (TyName "a")
+               ; effects     = Some Pure
+               ; decl_body   = e (Var "x") }))
 
 (* fn noop() { () } -- no return type annotation *)
 let test_fn_decl_no_annotation () =
   check_decl "fn no annotation"
     "fn noop() { () }"
-    (DeclFn { pub         = false
-            ; fn_name     = "noop"
-            ; type_params = []
-            ; params      = []
-            ; return_type = None
-            ; effects     = None
-            ; decl_body   = UnitLit })
+    (d (DeclFn { pub         = false
+               ; fn_name     = "noop"
+               ; type_params = []
+               ; params      = []
+               ; return_type = None
+               ; effects     = None
+               ; decl_body   = e UnitLit }))
 
 (* ------------------------------------------------------------------ *)
 (* type declarations                                                    *)
@@ -87,31 +93,31 @@ let test_fn_decl_no_annotation () =
 let test_type_decl_option () =
   check_decl "type Option"
     "type Option<a> = | None | Some(a)"
-    (DeclType { pub         = false
-              ; type_name   = "Option"
-              ; type_params = ["a"]
-              ; ctors       = [ { ctor_name = "None"; ctor_params = [] }
-                               ; { ctor_name = "Some"; ctor_params = [TyName "a"] } ] })
+    (d (DeclType { pub         = false
+                 ; type_name   = "Option"
+                 ; type_params = ["a"]
+                 ; ctors       = [ { ctor_name = "None"; ctor_params = [] }
+                                  ; { ctor_name = "Some"; ctor_params = [TyName "a"] } ] }))
 
 (* type Bool = | True | False *)
 let test_type_decl_bool () =
   check_decl "type Bool"
     "type Bool = | True | False"
-    (DeclType { pub         = false
-              ; type_name   = "Bool"
-              ; type_params = []
-              ; ctors       = [ { ctor_name = "True";  ctor_params = [] }
-                               ; { ctor_name = "False"; ctor_params = [] } ] })
+    (d (DeclType { pub         = false
+                 ; type_name   = "Bool"
+                 ; type_params = []
+                 ; ctors       = [ { ctor_name = "True";  ctor_params = [] }
+                                  ; { ctor_name = "False"; ctor_params = [] } ] }))
 
 (* pub type Result<a, e> = | Ok(a) | Err(e) *)
 let test_type_decl_result () =
   check_decl "type Result"
     "pub type Result<a, e> = | Ok(a) | Err(e)"
-    (DeclType { pub         = true
-              ; type_name   = "Result"
-              ; type_params = ["a"; "e"]
-              ; ctors       = [ { ctor_name = "Ok";  ctor_params = [TyName "a"] }
-                               ; { ctor_name = "Err"; ctor_params = [TyName "e"] } ] })
+    (d (DeclType { pub         = true
+                 ; type_name   = "Result"
+                 ; type_params = ["a"; "e"]
+                 ; ctors       = [ { ctor_name = "Ok";  ctor_params = [TyName "a"] }
+                                  ; { ctor_name = "Err"; ctor_params = [TyName "e"] } ] }))
 
 (* ------------------------------------------------------------------ *)
 (* effect declarations                                                  *)
@@ -121,26 +127,26 @@ let test_type_decl_result () =
 let test_effect_decl_state () =
   check_decl "effect State"
     "effect State<s> { get: () -> s, put: (s) -> Unit }"
-    (DeclEffect { pub         = false
-                ; effect_name = "State"
-                ; type_params = ["s"]
-                ; ops         = [ { effect_op_name   = "get"
-                                  ; effect_op_params  = []
-                                  ; effect_op_return  = TyName "s" }
-                                ; { effect_op_name   = "put"
-                                  ; effect_op_params  = [TyName "s"]
-                                  ; effect_op_return  = TyName "Unit" } ] })
+    (d (DeclEffect { pub         = false
+                   ; effect_name = "State"
+                   ; type_params = ["s"]
+                   ; ops         = [ { effect_op_name   = "get"
+                                     ; effect_op_params  = []
+                                     ; effect_op_return  = TyName "s" }
+                                   ; { effect_op_name   = "put"
+                                     ; effect_op_params  = [TyName "s"]
+                                     ; effect_op_return  = TyName "Unit" } ] }))
 
 (* effect Log { log: (String) -> Unit } *)
 let test_effect_decl_log () =
   check_decl "effect Log"
     "effect Log { log: (String) -> Unit }"
-    (DeclEffect { pub         = false
-                ; effect_name = "Log"
-                ; type_params = []
-                ; ops         = [ { effect_op_name   = "log"
-                                  ; effect_op_params  = [TyName "String"]
-                                  ; effect_op_return  = TyName "Unit" } ] })
+    (d (DeclEffect { pub         = false
+                   ; effect_name = "Log"
+                   ; type_params = []
+                   ; ops         = [ { effect_op_name   = "log"
+                                     ; effect_op_params  = [TyName "String"]
+                                     ; effect_op_return  = TyName "Unit" } ] }))
 
 (* ------------------------------------------------------------------ *)
 (* module declarations                                                  *)
@@ -150,16 +156,16 @@ let test_effect_decl_log () =
 let test_module_decl () =
   check_decl "module"
     "module math { fn square(x: Int) { x } }"
-    (DeclModule { pub         = false
-                ; module_name = "math"
-                ; body        =
-                    [ DeclFn { pub         = false
-                              ; fn_name     = "square"
-                              ; type_params = []
-                              ; params      = [{ param_name = "x"; param_type = TyName "Int" }]
-                              ; return_type = None
-                              ; effects     = None
-                              ; decl_body   = Var "x" } ] })
+    (d (DeclModule { pub         = false
+                   ; module_name = "math"
+                   ; body        =
+                       [ d (DeclFn { pub         = false
+                                   ; fn_name     = "square"
+                                   ; type_params = []
+                                   ; params      = [{ param_name = "x"; param_type = TyName "Int" }]
+                                   ; return_type = None
+                                   ; effects     = None
+                                   ; decl_body   = e (Var "x") }) ] }))
 
 (* ------------------------------------------------------------------ *)
 (* require declarations                                                 *)
@@ -169,7 +175,7 @@ let test_module_decl () =
 let test_require_decl () =
   check_decl "require"
     "require effect Log"
-    (DeclRequire (TyName "Log"))
+    (d (DeclRequire (TyName "Log")))
 
 (* ------------------------------------------------------------------ *)
 (* Multi-declaration programs                                           *)
@@ -179,12 +185,34 @@ let test_require_decl () =
 let test_program_two_fns () =
   check_prog "two fns"
     "fn foo(x: Int) { x }  fn bar(y: Bool) { y }"
-    [ DeclFn { pub = false; fn_name = "foo"; type_params = []
-             ; params = [{ param_name = "x"; param_type = TyName "Int" }]
-             ; return_type = None; effects = None; decl_body = Var "x" }
-    ; DeclFn { pub = false; fn_name = "bar"; type_params = []
-             ; params = [{ param_name = "y"; param_type = TyName "Bool" }]
-             ; return_type = None; effects = None; decl_body = Var "y" } ]
+    [ d (DeclFn { pub = false; fn_name = "foo"; type_params = []
+                ; params = [{ param_name = "x"; param_type = TyName "Int" }]
+                ; return_type = None; effects = None; decl_body = e (Var "x") })
+    ; d (DeclFn { pub = false; fn_name = "bar"; type_params = []
+                ; params = [{ param_name = "y"; param_type = TyName "Bool" }]
+                ; return_type = None; effects = None; decl_body = e (Var "y") }) ]
+
+(* ------------------------------------------------------------------ *)
+(* Comment attachment on declarations                                   *)
+(* ------------------------------------------------------------------ *)
+
+(* fn foo(x: Int) { x } @# entry point #@ *)
+let test_fn_decl_comment () =
+  check_decl "fn with comment"
+    "fn foo(x: Int) { x } @# entry point #@"
+    { decl_kind = DeclFn { pub = false; fn_name = "foo"; type_params = []
+                          ; params = [{ param_name = "x"; param_type = TyName "Int" }]
+                          ; return_type = None; effects = None; decl_body = e (Var "x") }
+    ; decl_comment = Some "entry point" }
+
+(* type Bool = | True | False @# boolean type #@ *)
+let test_type_decl_comment () =
+  check_decl "type with comment"
+    "type Bool = | True | False @# boolean type #@"
+    { decl_kind = DeclType { pub = false; type_name = "Bool"; type_params = []
+                            ; ctors = [ { ctor_name = "True"; ctor_params = [] }
+                                       ; { ctor_name = "False"; ctor_params = [] } ] }
+    ; decl_comment = Some "boolean type" }
 
 (* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
@@ -215,4 +243,8 @@ let () =
         ] )
     ; ( "program",
         [ Alcotest.test_case "two fns"         `Quick test_program_two_fns
+        ] )
+    ; ( "comments",
+        [ Alcotest.test_case "fn comment"      `Quick test_fn_decl_comment
+        ; Alcotest.test_case "type comment"    `Quick test_type_decl_comment
         ] ) ]

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -156,6 +156,35 @@ let test_lex_line_comment () =
     [ Let; In ]
 
 (* ------------------------------------------------------------------ *)
+(* Node-attached comment tests (@# ... #@)                              *)
+(* ------------------------------------------------------------------ *)
+
+let test_lex_comment_simple () =
+  check_tokens "simple comment"
+    "42 @# the answer #@"
+    [ IntLit 42; Comment "the answer" ]
+
+let test_lex_comment_multiword () =
+  check_tokens "multiword comment"
+    "x @# this is a longer comment #@"
+    [ Ident "x"; Comment "this is a longer comment" ]
+
+let test_lex_comment_whitespace_trimmed () =
+  check_tokens "comment whitespace trimmed"
+    "x @#   padded   #@"
+    [ Ident "x"; Comment "padded" ]
+
+let test_lex_comment_between_tokens () =
+  check_tokens "comment between tokens"
+    "let x = 42 @# the value #@ in x"
+    [ Let; Ident "x"; Equal; IntLit 42; Comment "the value"; In; Ident "x" ]
+
+let test_lex_comment_multiline () =
+  check_tokens "multiline comment"
+    "x @# line one\nline two #@"
+    [ Ident "x"; Comment "line one\nline two" ]
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -235,5 +264,12 @@ let () =
         ; Alcotest.test_case "newline ignored" `Quick test_lex_newline_ignored
         ; Alcotest.test_case "multi-token" `Quick test_lex_multi_token
         ; Alcotest.test_case "line comment" `Quick test_lex_line_comment
+        ] )
+    ; ( "node-comments",
+        [ Alcotest.test_case "simple"              `Quick test_lex_comment_simple
+        ; Alcotest.test_case "multiword"           `Quick test_lex_comment_multiword
+        ; Alcotest.test_case "whitespace trimmed"  `Quick test_lex_comment_whitespace_trimmed
+        ; Alcotest.test_case "between tokens"      `Quick test_lex_comment_between_tokens
+        ; Alcotest.test_case "multiline"           `Quick test_lex_comment_multiline
         ] )
     ]

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -411,39 +411,39 @@ let test_paren_var () =
 let test_comment_on_atom () =
   check_expr "comment on literal"
     "42 @# the answer #@"
-    { kind = IntLit 42; comment = Some "the answer" }
+    { desc = IntLit 42; comment = Some "the answer" }
 
 (* let x = 42 @# the answer #@ in x *)
 let test_comment_on_value () =
   check_expr "comment on let value"
     "let x = 42 @# the answer #@ in x"
     (e (Let { pat = p (PVar "x")
-            ; value = { kind = IntLit 42; comment = Some "the answer" }
+            ; value = { desc = IntLit 42; comment = Some "the answer" }
             ; body = e (Var "x") }))
 
 (* f(42) @# function call #@ *)
 let test_comment_on_app () =
   check_expr "comment on application"
     "f(42) @# function call #@"
-    { kind = App (e (Var "f"), [e (IntLit 42)]); comment = Some "function call" }
+    { desc = App (e (Var "f"), [e (IntLit 42)]); comment = Some "function call" }
 
 (* (x) @# grouped #@ *)
 let test_comment_on_paren () =
   check_expr "comment on parenthesised"
     "(x) @# grouped #@"
-    { kind = Var "x"; comment = Some "grouped" }
+    { desc = Var "x"; comment = Some "grouped" }
 
 (* f(42 @# the arg #@) *)
 let test_comment_on_arg () =
   check_expr "comment on arg"
     "f(42 @# the arg #@)"
-    (e (App (e (Var "f"), [{ kind = IntLit 42; comment = Some "the arg" }])))
+    (e (App (e (Var "f"), [{ desc = IntLit 42; comment = Some "the arg" }])))
 
 (* p.x @# field access #@ *)
 let test_comment_on_project () =
   check_expr "comment on projection"
     "p.x @# field access #@"
-    { kind = Project (e (Var "p"), "x"); comment = Some "field access" }
+    { desc = Project (e (Var "p"), "x"); comment = Some "field access" }
 
 let () =
   Alcotest.run "Parser"

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -13,12 +13,6 @@ let parse_expr_of src =
 let check_expr label src expected =
   Alcotest.(check expr_testable) label expected (parse_expr_of src)
 
-(** Shorthand: build an expression node with no comment. *)
-let e k = expr k
-
-(** Shorthand: build a pattern node with no comment. *)
-let p k = pat k
-
 (* ------------------------------------------------------------------ *)
 (* Let expression tests                                                 *)
 (* ------------------------------------------------------------------ *)
@@ -26,41 +20,41 @@ let p k = pat k
 let test_let_int_body_var () =
   check_expr "let x = 42 in x"
     "let x = 42 in x"
-    (e (Let { pat = p (PVar "x"); value = e (IntLit 42); body = e (Var "x") }))
+    (expr (Let { pat = pat (PVar "x"); value = expr (IntLit 42); body = expr (Var "x") }))
 
 let test_let_bool () =
   check_expr "let x = true in x"
     "let x = true in x"
-    (e (Let { pat = p (PVar "x"); value = e (BoolLit true); body = e (Var "x") }))
+    (expr (Let { pat = pat (PVar "x"); value = expr (BoolLit true); body = expr (Var "x") }))
 
 let test_let_string () =
   check_expr {|let x = "hello" in x|}
     {|let x = "hello" in x|}
-    (e (Let { pat = p (PVar "x"); value = e (StringLit "hello"); body = e (Var "x") }))
+    (expr (Let { pat = pat (PVar "x"); value = expr (StringLit "hello"); body = expr (Var "x") }))
 
 let test_let_unit () =
   check_expr "let x = () in x"
     "let x = () in x"
-    (e (Let { pat = p (PVar "x"); value = e UnitLit; body = e (Var "x") }))
+    (expr (Let { pat = pat (PVar "x"); value = expr UnitLit; body = expr (Var "x") }))
 
 let test_let_nested () =
   check_expr "nested let"
     "let x = 1 in let y = 2 in x"
-    (e (Let { pat = p (PVar "x"); value = e (IntLit 1)
-            ; body = e (Let { pat = p (PVar "y"); value = e (IntLit 2)
-                            ; body = e (Var "x") }) }))
+    (expr (Let { pat = pat (PVar "x"); value = expr (IntLit 1)
+            ; body = expr (Let { pat = pat (PVar "y"); value = expr (IntLit 2)
+                            ; body = expr (Var "x") }) }))
 
 let test_let_var_value () =
   check_expr "let y = x in y"
     "let y = x in y"
-    (e (Let { pat = p (PVar "y"); value = e (Var "x"); body = e (Var "y") }))
+    (expr (Let { pat = pat (PVar "y"); value = expr (Var "x"); body = expr (Var "y") }))
 
 let test_let_chain_var () =
   check_expr "chained var binding"
     "let a = 1 in let b = a in b"
-    (e (Let { pat = p (PVar "a"); value = e (IntLit 1)
-            ; body = e (Let { pat = p (PVar "b"); value = e (Var "a")
-                            ; body = e (Var "b") }) }))
+    (expr (Let { pat = pat (PVar "a"); value = expr (IntLit 1)
+            ; body = expr (Let { pat = pat (PVar "b"); value = expr (Var "a")
+                            ; body = expr (Var "b") }) }))
 
 (* ------------------------------------------------------------------ *)
 (* Function application                                                 *)
@@ -69,28 +63,28 @@ let test_let_chain_var () =
 let test_app_single_arg () =
   check_expr "f(42)"
     "f(42)"
-    (e (App (e (Var "f"), [e (IntLit 42)])))
+    (expr (App (expr (Var "f"), [expr (IntLit 42)])))
 
 let test_app_multi_arg () =
   check_expr "f(x, y)"
     "f(x, y)"
-    (e (App (e (Var "f"), [e (Var "x"); e (Var "y")])))
+    (expr (App (expr (Var "f"), [expr (Var "x"); expr (Var "y")])))
 
 let test_app_no_args () =
   check_expr "f()"
     "f()"
-    (e (App (e (Var "f"), [])))
+    (expr (App (expr (Var "f"), [])))
 
 let test_app_nested () =
   check_expr "f(g(x))"
     "f(g(x))"
-    (e (App (e (Var "f"), [e (App (e (Var "g"), [e (Var "x")]))])))
+    (expr (App (expr (Var "f"), [expr (App (expr (Var "g"), [expr (Var "x")]))])))
 
 let test_app_in_let () =
   check_expr "let x = f(42) in x"
     "let x = f(42) in x"
-    (e (Let { pat = p (PVar "x"); value = e (App (e (Var "f"), [e (IntLit 42)]))
-            ; body = e (Var "x") }))
+    (expr (Let { pat = pat (PVar "x"); value = expr (App (expr (Var "f"), [expr (IntLit 42)]))
+            ; body = expr (Var "x") }))
 
 (* ------------------------------------------------------------------ *)
 (* fn expressions                                                       *)
@@ -100,66 +94,66 @@ let test_app_in_let () =
 let test_fn_identity_annotated () =
   check_expr "fn (x: Int) -> Int ! pure { x }"
     "fn (x: Int) -> Int ! pure { x }"
-    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+    (expr (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
            ; return_type = Some (TyName "Int")
            ; effects     = Some Pure
-           ; fn_body     = e (Var "x") }))
+           ; fn_body     = expr (Var "x") }))
 
 (* fn (x: Int, y: Int) -> Int ! pure { x } *)
 let test_fn_two_params () =
   check_expr "fn with two params"
     "fn (x: Int, y: Int) -> Int ! pure { x }"
-    (e (Fn { params      = [ { param_name = "x"; param_type = TyName "Int" }
+    (expr (Fn { params      = [ { param_name = "x"; param_type = TyName "Int" }
                             ; { param_name = "y"; param_type = TyName "Int" } ]
            ; return_type = Some (TyName "Int")
            ; effects     = Some Pure
-           ; fn_body     = e (Var "x") }))
+           ; fn_body     = expr (Var "x") }))
 
 (* fn () -> Unit ! pure { () }  — zero params *)
 let test_fn_no_params () =
   check_expr "fn no params"
     "fn () -> Unit ! pure { () }"
-    (e (Fn { params      = []
+    (expr (Fn { params      = []
            ; return_type = Some (TyName "Unit")
            ; effects     = Some Pure
-           ; fn_body     = e UnitLit }))
+           ; fn_body     = expr UnitLit }))
 
 (* fn (x: Int) -> Int ! pure { x }  body is an application *)
 let test_fn_body_app () =
   check_expr "fn body is application"
     "fn (x: Int) -> Int ! pure { f(x) }"
-    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+    (expr (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
            ; return_type = Some (TyName "Int")
            ; effects     = Some Pure
-           ; fn_body     = e (App (e (Var "f"), [e (Var "x")])) }))
+           ; fn_body     = expr (App (expr (Var "f"), [expr (Var "x")])) }))
 
 (* Without return type annotation — optional in body position *)
 let test_fn_no_annotation () =
   check_expr "fn without annotation"
     "fn (x: Int) { x }"
-    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+    (expr (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
            ; return_type = None
            ; effects     = None
-           ; fn_body     = e (Var "x") }))
+           ; fn_body     = expr (Var "x") }))
 
 (* Parameterised type: fn (xs: List<Int>) -> Int ! pure { 0 } *)
 let test_fn_generic_param () =
   check_expr "fn with generic param type"
     "fn (xs: List<Int>) -> Int ! pure { 0 }"
-    (e (Fn { params      = [{ param_name = "xs"
+    (expr (Fn { params      = [{ param_name = "xs"
                              ; param_type = TyApp ("List", [TyName "Int"]) }]
            ; return_type = Some (TyName "Int")
            ; effects     = Some Pure
-           ; fn_body     = e (IntLit 0) }))
+           ; fn_body     = expr (IntLit 0) }))
 
 (* Effect set with named effects: fn (x: Int) -> Int ! {Log, Throw<E>} { x } *)
 let test_fn_effect_set () =
   check_expr "fn with effect set"
     "fn (x: Int) -> Int ! {Log} { x }"
-    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+    (expr (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
            ; return_type = Some (TyName "Int")
            ; effects     = Some (Effects [TyName "Log"])
-           ; fn_body     = e (Var "x") }))
+           ; fn_body     = expr (Var "x") }))
 
 (* ------------------------------------------------------------------ *)
 (* match expressions                                                    *)
@@ -169,32 +163,32 @@ let test_fn_effect_set () =
 let test_match_bool_arms () =
   check_expr "match bool"
     "match x with { | true => 1 | false => 0 }"
-    (e (Match { scrutinee = e (Var "x")
-              ; arms = [ { pattern = p (PLit (LBool true));  arm_body = e (IntLit 1) }
-                       ; { pattern = p (PLit (LBool false)); arm_body = e (IntLit 0) } ] }))
+    (expr (Match { scrutinee = expr (Var "x")
+              ; arms = [ { pattern = pat (PLit (LBool true));  arm_body = expr (IntLit 1) }
+                       ; { pattern = pat (PLit (LBool false)); arm_body = expr (IntLit 0) } ] }))
 
 (* match n with { | 0 => true | _ => false } *)
 let test_match_wildcard () =
   check_expr "match with wildcard"
     "match n with { | 0 => true | _ => false }"
-    (e (Match { scrutinee = e (Var "n")
-              ; arms = [ { pattern = p (PLit (LInt 0)); arm_body = e (BoolLit true) }
-                       ; { pattern = p PWild;            arm_body = e (BoolLit false) } ] }))
+    (expr (Match { scrutinee = expr (Var "n")
+              ; arms = [ { pattern = pat (PLit (LInt 0)); arm_body = expr (BoolLit true) }
+                       ; { pattern = pat PWild;            arm_body = expr (BoolLit false) } ] }))
 
 (* match opt with { | Some(x) => x | None => 0 } *)
 let test_match_constructor () =
   check_expr "match constructor"
     "match opt with { | Some(x) => x | None => 0 }"
-    (e (Match { scrutinee = e (Var "opt")
-              ; arms = [ { pattern = p (PCtor ("Some", [p (PVar "x")])); arm_body = e (Var "x") }
-                       ; { pattern = p (PCtor ("None", []));              arm_body = e (IntLit 0) } ] }))
+    (expr (Match { scrutinee = expr (Var "opt")
+              ; arms = [ { pattern = pat (PCtor ("Some", [pat (PVar "x")])); arm_body = expr (Var "x") }
+                       ; { pattern = pat (PCtor ("None", []));              arm_body = expr (IntLit 0) } ] }))
 
 (* match x with { | y => y }  -- variable binding pattern *)
 let test_match_var_pattern () =
   check_expr "match var pattern"
     "match x with { | y => y }"
-    (e (Match { scrutinee = e (Var "x")
-              ; arms = [ { pattern = p (PVar "y"); arm_body = e (Var "y") } ] }))
+    (expr (Match { scrutinee = expr (Var "x")
+              ; arms = [ { pattern = pat (PVar "y"); arm_body = expr (Var "y") } ] }))
 
 (* ------------------------------------------------------------------ *)
 (* if / else                                                            *)
@@ -204,23 +198,23 @@ let test_match_var_pattern () =
 let test_if_basic () =
   check_expr "if basic"
     "if b { 1 } else { 0 }"
-    (e (If { cond = e (Var "b"); then_ = e (IntLit 1); else_ = e (IntLit 0) }))
+    (expr (If { cond = expr (Var "b"); then_ = expr (IntLit 1); else_ = expr (IntLit 0) }))
 
 (* if cond { f(x) } else { g(x) } *)
 let test_if_app_body () =
   check_expr "if with app body"
     "if cond { f(x) } else { g(x) }"
-    (e (If { cond = e (Var "cond")
-           ; then_ = e (App (e (Var "f"), [e (Var "x")]))
-           ; else_ = e (App (e (Var "g"), [e (Var "x")])) }))
+    (expr (If { cond = expr (Var "cond")
+           ; then_ = expr (App (expr (Var "f"), [expr (Var "x")]))
+           ; else_ = expr (App (expr (Var "g"), [expr (Var "x")])) }))
 
 (* if a { if b { 1 } else { 2 } } else { 3 } *)
 let test_if_nested () =
   check_expr "nested if"
     "if a { if b { 1 } else { 2 } } else { 3 }"
-    (e (If { cond  = e (Var "a")
-           ; then_ = e (If { cond = e (Var "b"); then_ = e (IntLit 1); else_ = e (IntLit 2) })
-           ; else_ = e (IntLit 3) }))
+    (expr (If { cond  = expr (Var "a")
+           ; then_ = expr (If { cond = expr (Var "b"); then_ = expr (IntLit 1); else_ = expr (IntLit 2) })
+           ; else_ = expr (IntLit 3) }))
 
 (* ------------------------------------------------------------------ *)
 (* handle expressions                                                   *)
@@ -237,32 +231,32 @@ let test_if_nested () =
 let test_handle_state () =
   check_expr "handle State"
     "handle computation() with { State { get() => resume(s) \n put(v) => resume(()) } }"
-    (e (Handle
-       { handled   = e (App (e (Var "computation"), []))
+    (expr (Handle
+       { handled   = expr (App (expr (Var "computation"), []))
        ; handlers  =
            [ { effect_handler = "State"
              ; op_handlers    =
                  [ { op_handler_name   = "get"
                    ; op_handler_params = []
-                   ; op_handler_body   = e (App (e (Var "resume"), [e (Var "s")])) }
+                   ; op_handler_body   = expr (App (expr (Var "resume"), [expr (Var "s")])) }
                  ; { op_handler_name   = "put"
                    ; op_handler_params = ["v"]
-                   ; op_handler_body   = e (App (e (Var "resume"), [e UnitLit])) } ]
+                   ; op_handler_body   = expr (App (expr (Var "resume"), [expr UnitLit])) } ]
              ; return_handler = None } ] }))
 
 (* handle with a return branch *)
 let test_handle_return_branch () =
   check_expr "handle with return"
     "handle f() with { Throw { throw(e) => e \n return v => v } }"
-    (e (Handle
-       { handled  = e (App (e (Var "f"), []))
+    (expr (Handle
+       { handled  = expr (App (expr (Var "f"), []))
        ; handlers =
            [ { effect_handler = "Throw"
              ; op_handlers    =
                  [ { op_handler_name   = "throw"
                    ; op_handler_params = ["e"]
-                   ; op_handler_body   = e (Var "e") } ]
-             ; return_handler = Some { return_var = "v"; return_body = e (Var "v") } } ] }))
+                   ; op_handler_body   = expr (Var "e") } ]
+             ; return_handler = Some { return_var = "v"; return_body = expr (Var "v") } } ] }))
 
 (* ------------------------------------------------------------------ *)
 (* perform                                                              *)
@@ -272,28 +266,28 @@ let test_handle_return_branch () =
 let test_perform_basic () =
   check_expr "perform basic"
     {|perform Console.print("hi")|}
-    (e (Perform { effect_name = "Console"; op_name = "print"
-                ; args = [e (StringLit "hi")] }))
+    (expr (Perform { effect_name = "Console"; op_name = "print"
+                ; args = [expr (StringLit "hi")] }))
 
 (* perform State.get() -- zero args *)
 let test_perform_no_args () =
   check_expr "perform no args"
     "perform State.get()"
-    (e (Perform { effect_name = "State"; op_name = "get"; args = [] }))
+    (expr (Perform { effect_name = "State"; op_name = "get"; args = [] }))
 
 (* perform Throw.throw(KeyNotFound(key)) -- ctor arg *)
 let test_perform_ctor_arg () =
   check_expr "perform ctor arg"
     "perform Throw.throw(err)"
-    (e (Perform { effect_name = "Throw"; op_name = "throw"; args = [e (Var "err")] }))
+    (expr (Perform { effect_name = "Throw"; op_name = "throw"; args = [expr (Var "err")] }))
 
 (* inside a do block *)
 let test_perform_in_do () =
   check_expr "perform in do"
     {|do { perform Log.log(msg); x }|}
-    (e (Do [ StmtExpr (e (Perform { effect_name = "Log"; op_name = "log"
-                                   ; args = [e (Var "msg")] }))
-           ; StmtExpr (e (Var "x")) ]))
+    (expr (Do [ StmtExpr (expr (Perform { effect_name = "Log"; op_name = "log"
+                                   ; args = [expr (Var "msg")] }))
+           ; StmtExpr (expr (Var "x")) ]))
 
 (* ------------------------------------------------------------------ *)
 (* do blocks                                                            *)
@@ -303,27 +297,27 @@ let test_perform_in_do () =
 let test_do_single () =
   check_expr "do single expr"
     "do { x }"
-    (e (Do [StmtExpr (e (Var "x"))]))
+    (expr (Do [StmtExpr (expr (Var "x"))]))
 
 (* do { f(); x }  -- effect stmt then result *)
 let test_do_effect_then_result () =
   check_expr "do effect then result"
     "do { f(); x }"
-    (e (Do [StmtExpr (e (App (e (Var "f"), []))); StmtExpr (e (Var "x"))]))
+    (expr (Do [StmtExpr (expr (App (expr (Var "f"), []))); StmtExpr (expr (Var "x"))]))
 
 (* do { let x = 42; x }  -- let stmt (no 'in') *)
 let test_do_let_stmt () =
   check_expr "do let stmt"
     "do { let x = 42; x }"
-    (e (Do [StmtLet { pat = p (PVar "x"); value = e (IntLit 42) }; StmtExpr (e (Var "x"))]))
+    (expr (Do [StmtLet { pat = pat (PVar "x"); value = expr (IntLit 42) }; StmtExpr (expr (Var "x"))]))
 
 (* do { let a = 1; let b = 2; a }  -- multiple let stmts *)
 let test_do_multi_let () =
   check_expr "do multi let"
     "do { let a = 1; let b = 2; a }"
-    (e (Do [ StmtLet { pat = p (PVar "a"); value = e (IntLit 1) }
-           ; StmtLet { pat = p (PVar "b"); value = e (IntLit 2) }
-           ; StmtExpr (e (Var "a")) ]))
+    (expr (Do [ StmtLet { pat = pat (PVar "a"); value = expr (IntLit 1) }
+           ; StmtLet { pat = pat (PVar "b"); value = expr (IntLit 2) }
+           ; StmtExpr (expr (Var "a")) ]))
 
 (* ------------------------------------------------------------------ *)
 (* letrec expressions                                                   *)
@@ -333,27 +327,27 @@ let test_do_multi_let () =
 let test_letrec_single () =
   check_expr "letrec single"
     "letrec { f(x: Int): Int = x } in f(42)"
-    (e (Letrec
+    (expr (Letrec
        ( [ { letrec_name = "f"
            ; letrec_params = [{ param_name = "x"; param_type = TyName "Int" }]
            ; letrec_return_type = TyName "Int"
-           ; letrec_body = e (Var "x") } ]
-       , e (App (e (Var "f"), [e (IntLit 42)])) )))
+           ; letrec_body = expr (Var "x") } ]
+       , expr (App (expr (Var "f"), [expr (IntLit 42)])) )))
 
 (* letrec { even(n: Int): Bool = n, odd(n: Int): Bool = n } in even(0) *)
 let test_letrec_mutual () =
   check_expr "letrec mutual"
     "letrec { even(n: Int): Bool = n, odd(n: Int): Bool = n } in even(0)"
-    (e (Letrec
+    (expr (Letrec
        ( [ { letrec_name = "even"
            ; letrec_params = [{ param_name = "n"; param_type = TyName "Int" }]
            ; letrec_return_type = TyName "Bool"
-           ; letrec_body = e (Var "n") }
+           ; letrec_body = expr (Var "n") }
          ; { letrec_name = "odd"
            ; letrec_params = [{ param_name = "n"; param_type = TyName "Int" }]
            ; letrec_return_type = TyName "Bool"
-           ; letrec_body = e (Var "n") } ]
-       , e (App (e (Var "even"), [e (IntLit 0)])) )))
+           ; letrec_body = expr (Var "n") } ]
+       , expr (App (expr (Var "even"), [expr (IntLit 0)])) )))
 
 (* ------------------------------------------------------------------ *)
 (* Record literals, updates, and projection                            *)
@@ -363,31 +357,31 @@ let test_letrec_mutual () =
 let test_record_empty () =
   check_expr "empty record"
     "{}"
-    (e (Record []))
+    (expr (Record []))
 
 (* { x: 1, y: 2 } *)
 let test_record_literal () =
   check_expr "record literal"
     "{ x: 1, y: 2 }"
-    (e (Record [("x", e (IntLit 1)); ("y", e (IntLit 2))]))
+    (expr (Record [("x", expr (IntLit 1)); ("y", expr (IntLit 2))]))
 
 (* { p with x: 3 } -- record update *)
 let test_record_update () =
   check_expr "record update"
     "{ p with x: 3 }"
-    (e (RecordUpdate (e (Var "p"), [("x", e (IntLit 3))])))
+    (expr (RecordUpdate (expr (Var "p"), [("x", expr (IntLit 3))])))
 
 (* p.x -- field projection *)
 let test_project_field () =
   check_expr "project field"
     "p.x"
-    (e (Project (e (Var "p"), "x")))
+    (expr (Project (expr (Var "p"), "x")))
 
 (* p.x.y -- chained projection *)
 let test_project_chain () =
   check_expr "chained projection"
     "p.x.y"
-    (e (Project (e (Project (e (Var "p"), "x")), "y")))
+    (expr (Project (expr (Project (expr (Var "p"), "x")), "y")))
 
 (* ------------------------------------------------------------------ *)
 (* Parenthesised expressions                                            *)
@@ -396,12 +390,12 @@ let test_project_chain () =
 let test_paren_grouping () =
   check_expr "parenthesised expression"
     "(42)"
-    (e (IntLit 42))
+    (expr (IntLit 42))
 
 let test_paren_var () =
   check_expr "parenthesised var"
     "(x)"
-    (e (Var "x"))
+    (expr (Var "x"))
 
 (* ------------------------------------------------------------------ *)
 (* Comment attachment on expressions                                    *)
@@ -417,15 +411,15 @@ let test_comment_on_atom () =
 let test_comment_on_value () =
   check_expr "comment on let value"
     "let x = 42 @# the answer #@ in x"
-    (e (Let { pat = p (PVar "x")
+    (expr (Let { pat = pat (PVar "x")
             ; value = { desc = IntLit 42; comment = Some "the answer" }
-            ; body = e (Var "x") }))
+            ; body = expr (Var "x") }))
 
 (* f(42) @# function call #@ *)
 let test_comment_on_app () =
   check_expr "comment on application"
     "f(42) @# function call #@"
-    { desc = App (e (Var "f"), [e (IntLit 42)]); comment = Some "function call" }
+    { desc = App (expr (Var "f"), [expr (IntLit 42)]); comment = Some "function call" }
 
 (* (x) @# grouped #@ *)
 let test_comment_on_paren () =
@@ -437,13 +431,13 @@ let test_comment_on_paren () =
 let test_comment_on_arg () =
   check_expr "comment on arg"
     "f(42 @# the arg #@)"
-    (e (App (e (Var "f"), [{ desc = IntLit 42; comment = Some "the arg" }])))
+    (expr (App (expr (Var "f"), [{ desc = IntLit 42; comment = Some "the arg" }])))
 
 (* p.x @# field access #@ *)
 let test_comment_on_project () =
   check_expr "comment on projection"
     "p.x @# field access #@"
-    { desc = Project (e (Var "p"), "x"); comment = Some "field access" }
+    { desc = Project (expr (Var "p"), "x"); comment = Some "field access" }
 
 let () =
   Alcotest.run "Parser"

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -13,6 +13,12 @@ let parse_expr_of src =
 let check_expr label src expected =
   Alcotest.(check expr_testable) label expected (parse_expr_of src)
 
+(** Shorthand: build an expression node with no comment. *)
+let e k = expr k
+
+(** Shorthand: build a pattern node with no comment. *)
+let p k = pat k
+
 (* ------------------------------------------------------------------ *)
 (* Let expression tests                                                 *)
 (* ------------------------------------------------------------------ *)
@@ -20,39 +26,41 @@ let check_expr label src expected =
 let test_let_int_body_var () =
   check_expr "let x = 42 in x"
     "let x = 42 in x"
-    (Let { pat = PVar "x"; value = IntLit 42; body = Var "x" })
+    (e (Let { pat = p (PVar "x"); value = e (IntLit 42); body = e (Var "x") }))
 
 let test_let_bool () =
   check_expr "let x = true in x"
     "let x = true in x"
-    (Let { pat = PVar "x"; value = BoolLit true; body = Var "x" })
+    (e (Let { pat = p (PVar "x"); value = e (BoolLit true); body = e (Var "x") }))
 
 let test_let_string () =
   check_expr {|let x = "hello" in x|}
     {|let x = "hello" in x|}
-    (Let { pat = PVar "x"; value = StringLit "hello"; body = Var "x" })
+    (e (Let { pat = p (PVar "x"); value = e (StringLit "hello"); body = e (Var "x") }))
 
 let test_let_unit () =
   check_expr "let x = () in x"
     "let x = () in x"
-    (Let { pat = PVar "x"; value = UnitLit; body = Var "x" })
+    (e (Let { pat = p (PVar "x"); value = e UnitLit; body = e (Var "x") }))
 
 let test_let_nested () =
   check_expr "nested let"
     "let x = 1 in let y = 2 in x"
-    (Let { pat = PVar "x"; value = IntLit 1
-         ; body = Let { pat = PVar "y"; value = IntLit 2; body = Var "x" } })
+    (e (Let { pat = p (PVar "x"); value = e (IntLit 1)
+            ; body = e (Let { pat = p (PVar "y"); value = e (IntLit 2)
+                            ; body = e (Var "x") }) }))
 
 let test_let_var_value () =
   check_expr "let y = x in y"
     "let y = x in y"
-    (Let { pat = PVar "y"; value = Var "x"; body = Var "y" })
+    (e (Let { pat = p (PVar "y"); value = e (Var "x"); body = e (Var "y") }))
 
 let test_let_chain_var () =
   check_expr "chained var binding"
     "let a = 1 in let b = a in b"
-    (Let { pat = PVar "a"; value = IntLit 1
-         ; body = Let { pat = PVar "b"; value = Var "a"; body = Var "b" } })
+    (e (Let { pat = p (PVar "a"); value = e (IntLit 1)
+            ; body = e (Let { pat = p (PVar "b"); value = e (Var "a")
+                            ; body = e (Var "b") }) }))
 
 (* ------------------------------------------------------------------ *)
 (* Function application                                                 *)
@@ -61,27 +69,28 @@ let test_let_chain_var () =
 let test_app_single_arg () =
   check_expr "f(42)"
     "f(42)"
-    (App (Var "f", [IntLit 42]))
+    (e (App (e (Var "f"), [e (IntLit 42)])))
 
 let test_app_multi_arg () =
   check_expr "f(x, y)"
     "f(x, y)"
-    (App (Var "f", [Var "x"; Var "y"]))
+    (e (App (e (Var "f"), [e (Var "x"); e (Var "y")])))
 
 let test_app_no_args () =
   check_expr "f()"
     "f()"
-    (App (Var "f", []))
+    (e (App (e (Var "f"), [])))
 
 let test_app_nested () =
   check_expr "f(g(x))"
     "f(g(x))"
-    (App (Var "f", [App (Var "g", [Var "x"])]))
+    (e (App (e (Var "f"), [e (App (e (Var "g"), [e (Var "x")]))])))
 
 let test_app_in_let () =
   check_expr "let x = f(42) in x"
     "let x = f(42) in x"
-    (Let { pat = PVar "x"; value = App (Var "f", [IntLit 42]); body = Var "x" })
+    (e (Let { pat = p (PVar "x"); value = e (App (e (Var "f"), [e (IntLit 42)]))
+            ; body = e (Var "x") }))
 
 (* ------------------------------------------------------------------ *)
 (* fn expressions                                                       *)
@@ -91,66 +100,66 @@ let test_app_in_let () =
 let test_fn_identity_annotated () =
   check_expr "fn (x: Int) -> Int ! pure { x }"
     "fn (x: Int) -> Int ! pure { x }"
-    (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
-        ; return_type = Some (TyName "Int")
-        ; effects     = Some Pure
-        ; fn_body     =Var "x" })
+    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+           ; return_type = Some (TyName "Int")
+           ; effects     = Some Pure
+           ; fn_body     = e (Var "x") }))
 
 (* fn (x: Int, y: Int) -> Int ! pure { x } *)
 let test_fn_two_params () =
   check_expr "fn with two params"
     "fn (x: Int, y: Int) -> Int ! pure { x }"
-    (Fn { params      = [ { param_name = "x"; param_type = TyName "Int" }
-                         ; { param_name = "y"; param_type = TyName "Int" } ]
-        ; return_type = Some (TyName "Int")
-        ; effects     = Some Pure
-        ; fn_body     =Var "x" })
+    (e (Fn { params      = [ { param_name = "x"; param_type = TyName "Int" }
+                            ; { param_name = "y"; param_type = TyName "Int" } ]
+           ; return_type = Some (TyName "Int")
+           ; effects     = Some Pure
+           ; fn_body     = e (Var "x") }))
 
 (* fn () -> Unit ! pure { () }  — zero params *)
 let test_fn_no_params () =
   check_expr "fn no params"
     "fn () -> Unit ! pure { () }"
-    (Fn { params      = []
-        ; return_type = Some (TyName "Unit")
-        ; effects     = Some Pure
-        ; fn_body     =UnitLit })
+    (e (Fn { params      = []
+           ; return_type = Some (TyName "Unit")
+           ; effects     = Some Pure
+           ; fn_body     = e UnitLit }))
 
 (* fn (x: Int) -> Int ! pure { x }  body is an application *)
 let test_fn_body_app () =
   check_expr "fn body is application"
     "fn (x: Int) -> Int ! pure { f(x) }"
-    (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
-        ; return_type = Some (TyName "Int")
-        ; effects     = Some Pure
-        ; fn_body     =App (Var "f", [Var "x"]) })
+    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+           ; return_type = Some (TyName "Int")
+           ; effects     = Some Pure
+           ; fn_body     = e (App (e (Var "f"), [e (Var "x")])) }))
 
 (* Without return type annotation — optional in body position *)
 let test_fn_no_annotation () =
   check_expr "fn without annotation"
     "fn (x: Int) { x }"
-    (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
-        ; return_type = None
-        ; effects     = None
-        ; fn_body     =Var "x" })
+    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+           ; return_type = None
+           ; effects     = None
+           ; fn_body     = e (Var "x") }))
 
 (* Parameterised type: fn (xs: List<Int>) -> Int ! pure { 0 } *)
 let test_fn_generic_param () =
   check_expr "fn with generic param type"
     "fn (xs: List<Int>) -> Int ! pure { 0 }"
-    (Fn { params      = [{ param_name = "xs"
-                         ; param_type = TyApp ("List", [TyName "Int"]) }]
-        ; return_type = Some (TyName "Int")
-        ; effects     = Some Pure
-        ; fn_body     =IntLit 0 })
+    (e (Fn { params      = [{ param_name = "xs"
+                             ; param_type = TyApp ("List", [TyName "Int"]) }]
+           ; return_type = Some (TyName "Int")
+           ; effects     = Some Pure
+           ; fn_body     = e (IntLit 0) }))
 
 (* Effect set with named effects: fn (x: Int) -> Int ! {Log, Throw<E>} { x } *)
 let test_fn_effect_set () =
   check_expr "fn with effect set"
     "fn (x: Int) -> Int ! {Log} { x }"
-    (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
-        ; return_type = Some (TyName "Int")
-        ; effects     = Some (Effects [TyName "Log"])
-        ; fn_body     =Var "x" })
+    (e (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
+           ; return_type = Some (TyName "Int")
+           ; effects     = Some (Effects [TyName "Log"])
+           ; fn_body     = e (Var "x") }))
 
 (* ------------------------------------------------------------------ *)
 (* match expressions                                                    *)
@@ -160,36 +169,32 @@ let test_fn_effect_set () =
 let test_match_bool_arms () =
   check_expr "match bool"
     "match x with { | true => 1 | false => 0 }"
-    (Match { scrutinee = Var "x"
-           ; arms = [ { pattern = PLit (LBool true);  arm_body = IntLit 1 }
-                    ; { pattern = PLit (LBool false); arm_body = IntLit 0 } ] })
+    (e (Match { scrutinee = e (Var "x")
+              ; arms = [ { pattern = p (PLit (LBool true));  arm_body = e (IntLit 1) }
+                       ; { pattern = p (PLit (LBool false)); arm_body = e (IntLit 0) } ] }))
 
 (* match n with { | 0 => true | _ => false } *)
 let test_match_wildcard () =
   check_expr "match with wildcard"
     "match n with { | 0 => true | _ => false }"
-    (Match { scrutinee = Var "n"
-           ; arms = [ { pattern = PLit (LInt 0); arm_body = BoolLit true }
-                    ; { pattern = PWild;          arm_body = BoolLit false } ] })
+    (e (Match { scrutinee = e (Var "n")
+              ; arms = [ { pattern = p (PLit (LInt 0)); arm_body = e (BoolLit true) }
+                       ; { pattern = p PWild;            arm_body = e (BoolLit false) } ] }))
 
 (* match opt with { | Some(x) => x | None => 0 } *)
 let test_match_constructor () =
   check_expr "match constructor"
     "match opt with { | Some(x) => x | None => 0 }"
-    (Match { scrutinee = Var "opt"
-           ; arms = [ { pattern = PCtor ("Some", [PVar "x"]); arm_body = Var "x" }
-                    ; { pattern = PCtor ("None", []);          arm_body = IntLit 0 } ] })
+    (e (Match { scrutinee = e (Var "opt")
+              ; arms = [ { pattern = p (PCtor ("Some", [p (PVar "x")])); arm_body = e (Var "x") }
+                       ; { pattern = p (PCtor ("None", []));              arm_body = e (IntLit 0) } ] }))
 
 (* match x with { | y => y }  -- variable binding pattern *)
 let test_match_var_pattern () =
   check_expr "match var pattern"
     "match x with { | y => y }"
-    (Match { scrutinee = Var "x"
-           ; arms = [ { pattern = PVar "y"; arm_body = Var "y" } ] })
-
-(* ------------------------------------------------------------------ *)
-(* Test runner                                                          *)
-(* ------------------------------------------------------------------ *)
+    (e (Match { scrutinee = e (Var "x")
+              ; arms = [ { pattern = p (PVar "y"); arm_body = e (Var "y") } ] }))
 
 (* ------------------------------------------------------------------ *)
 (* if / else                                                            *)
@@ -199,23 +204,23 @@ let test_match_var_pattern () =
 let test_if_basic () =
   check_expr "if basic"
     "if b { 1 } else { 0 }"
-    (If { cond = Var "b"; then_ = IntLit 1; else_ = IntLit 0 })
+    (e (If { cond = e (Var "b"); then_ = e (IntLit 1); else_ = e (IntLit 0) }))
 
 (* if cond { f(x) } else { g(x) } *)
 let test_if_app_body () =
   check_expr "if with app body"
     "if cond { f(x) } else { g(x) }"
-    (If { cond = Var "cond"
-        ; then_ = App (Var "f", [Var "x"])
-        ; else_ = App (Var "g", [Var "x"]) })
+    (e (If { cond = e (Var "cond")
+           ; then_ = e (App (e (Var "f"), [e (Var "x")]))
+           ; else_ = e (App (e (Var "g"), [e (Var "x")])) }))
 
 (* if a { if b { 1 } else { 2 } } else { 3 } *)
 let test_if_nested () =
   check_expr "nested if"
     "if a { if b { 1 } else { 2 } } else { 3 }"
-    (If { cond  = Var "a"
-        ; then_ = If { cond = Var "b"; then_ = IntLit 1; else_ = IntLit 2 }
-        ; else_ = IntLit 3 })
+    (e (If { cond  = e (Var "a")
+           ; then_ = e (If { cond = e (Var "b"); then_ = e (IntLit 1); else_ = e (IntLit 2) })
+           ; else_ = e (IntLit 3) }))
 
 (* ------------------------------------------------------------------ *)
 (* handle expressions                                                   *)
@@ -232,32 +237,32 @@ let test_if_nested () =
 let test_handle_state () =
   check_expr "handle State"
     "handle computation() with { State { get() => resume(s) \n put(v) => resume(()) } }"
-    (Handle
-       { handled   = App (Var "computation", [])
+    (e (Handle
+       { handled   = e (App (e (Var "computation"), []))
        ; handlers  =
            [ { effect_handler = "State"
              ; op_handlers    =
                  [ { op_handler_name   = "get"
                    ; op_handler_params = []
-                   ; op_handler_body   = App (Var "resume", [Var "s"]) }
+                   ; op_handler_body   = e (App (e (Var "resume"), [e (Var "s")])) }
                  ; { op_handler_name   = "put"
                    ; op_handler_params = ["v"]
-                   ; op_handler_body   = App (Var "resume", [UnitLit]) } ]
-             ; return_handler = None } ] })
+                   ; op_handler_body   = e (App (e (Var "resume"), [e UnitLit])) } ]
+             ; return_handler = None } ] }))
 
 (* handle with a return branch *)
 let test_handle_return_branch () =
   check_expr "handle with return"
     "handle f() with { Throw { throw(e) => e \n return v => v } }"
-    (Handle
-       { handled  = App (Var "f", [])
+    (e (Handle
+       { handled  = e (App (e (Var "f"), []))
        ; handlers =
            [ { effect_handler = "Throw"
              ; op_handlers    =
                  [ { op_handler_name   = "throw"
                    ; op_handler_params = ["e"]
-                   ; op_handler_body   = Var "e" } ]
-             ; return_handler = Some { return_var = "v"; return_body = Var "v" } } ] })
+                   ; op_handler_body   = e (Var "e") } ]
+             ; return_handler = Some { return_var = "v"; return_body = e (Var "v") } } ] }))
 
 (* ------------------------------------------------------------------ *)
 (* perform                                                              *)
@@ -267,28 +272,28 @@ let test_handle_return_branch () =
 let test_perform_basic () =
   check_expr "perform basic"
     {|perform Console.print("hi")|}
-    (Perform { effect_name = "Console"; op_name = "print"
-             ; args = [StringLit "hi"] })
+    (e (Perform { effect_name = "Console"; op_name = "print"
+                ; args = [e (StringLit "hi")] }))
 
 (* perform State.get() -- zero args *)
 let test_perform_no_args () =
   check_expr "perform no args"
     "perform State.get()"
-    (Perform { effect_name = "State"; op_name = "get"; args = [] })
+    (e (Perform { effect_name = "State"; op_name = "get"; args = [] }))
 
 (* perform Throw.throw(KeyNotFound(key)) -- ctor arg *)
 let test_perform_ctor_arg () =
   check_expr "perform ctor arg"
     "perform Throw.throw(err)"
-    (Perform { effect_name = "Throw"; op_name = "throw"; args = [Var "err"] })
+    (e (Perform { effect_name = "Throw"; op_name = "throw"; args = [e (Var "err")] }))
 
 (* inside a do block *)
 let test_perform_in_do () =
   check_expr "perform in do"
     {|do { perform Log.log(msg); x }|}
-    (Do [ StmtExpr (Perform { effect_name = "Log"; op_name = "log"
-                             ; args = [Var "msg"] })
-        ; StmtExpr (Var "x") ])
+    (e (Do [ StmtExpr (e (Perform { effect_name = "Log"; op_name = "log"
+                                   ; args = [e (Var "msg")] }))
+           ; StmtExpr (e (Var "x")) ]))
 
 (* ------------------------------------------------------------------ *)
 (* do blocks                                                            *)
@@ -298,27 +303,27 @@ let test_perform_in_do () =
 let test_do_single () =
   check_expr "do single expr"
     "do { x }"
-    (Do [StmtExpr (Var "x")])
+    (e (Do [StmtExpr (e (Var "x"))]))
 
 (* do { f(); x }  -- effect stmt then result *)
 let test_do_effect_then_result () =
   check_expr "do effect then result"
     "do { f(); x }"
-    (Do [StmtExpr (App (Var "f", [])); StmtExpr (Var "x")])
+    (e (Do [StmtExpr (e (App (e (Var "f"), []))); StmtExpr (e (Var "x"))]))
 
 (* do { let x = 42; x }  -- let stmt (no 'in') *)
 let test_do_let_stmt () =
   check_expr "do let stmt"
     "do { let x = 42; x }"
-    (Do [StmtLet { pat = PVar "x"; value = IntLit 42 }; StmtExpr (Var "x")])
+    (e (Do [StmtLet { pat = p (PVar "x"); value = e (IntLit 42) }; StmtExpr (e (Var "x"))]))
 
 (* do { let a = 1; let b = 2; a }  -- multiple let stmts *)
 let test_do_multi_let () =
   check_expr "do multi let"
     "do { let a = 1; let b = 2; a }"
-    (Do [ StmtLet { pat = PVar "a"; value = IntLit 1 }
-        ; StmtLet { pat = PVar "b"; value = IntLit 2 }
-        ; StmtExpr (Var "a") ])
+    (e (Do [ StmtLet { pat = p (PVar "a"); value = e (IntLit 1) }
+           ; StmtLet { pat = p (PVar "b"); value = e (IntLit 2) }
+           ; StmtExpr (e (Var "a")) ]))
 
 (* ------------------------------------------------------------------ *)
 (* letrec expressions                                                   *)
@@ -328,27 +333,27 @@ let test_do_multi_let () =
 let test_letrec_single () =
   check_expr "letrec single"
     "letrec { f(x: Int): Int = x } in f(42)"
-    (Letrec
+    (e (Letrec
        ( [ { letrec_name = "f"
            ; letrec_params = [{ param_name = "x"; param_type = TyName "Int" }]
            ; letrec_return_type = TyName "Int"
-           ; letrec_body = Var "x" } ]
-       , App (Var "f", [IntLit 42]) ))
+           ; letrec_body = e (Var "x") } ]
+       , e (App (e (Var "f"), [e (IntLit 42)])) )))
 
 (* letrec { even(n: Int): Bool = n, odd(n: Int): Bool = n } in even(0) *)
 let test_letrec_mutual () =
   check_expr "letrec mutual"
     "letrec { even(n: Int): Bool = n, odd(n: Int): Bool = n } in even(0)"
-    (Letrec
+    (e (Letrec
        ( [ { letrec_name = "even"
            ; letrec_params = [{ param_name = "n"; param_type = TyName "Int" }]
            ; letrec_return_type = TyName "Bool"
-           ; letrec_body = Var "n" }
+           ; letrec_body = e (Var "n") }
          ; { letrec_name = "odd"
            ; letrec_params = [{ param_name = "n"; param_type = TyName "Int" }]
            ; letrec_return_type = TyName "Bool"
-           ; letrec_body = Var "n" } ]
-       , App (Var "even", [IntLit 0]) ))
+           ; letrec_body = e (Var "n") } ]
+       , e (App (e (Var "even"), [e (IntLit 0)])) )))
 
 (* ------------------------------------------------------------------ *)
 (* Record literals, updates, and projection                            *)
@@ -358,31 +363,87 @@ let test_letrec_mutual () =
 let test_record_empty () =
   check_expr "empty record"
     "{}"
-    (Record [])
+    (e (Record []))
 
 (* { x: 1, y: 2 } *)
 let test_record_literal () =
   check_expr "record literal"
     "{ x: 1, y: 2 }"
-    (Record [("x", IntLit 1); ("y", IntLit 2)])
+    (e (Record [("x", e (IntLit 1)); ("y", e (IntLit 2))]))
 
 (* { p with x: 3 } -- record update *)
 let test_record_update () =
   check_expr "record update"
     "{ p with x: 3 }"
-    (RecordUpdate (Var "p", [("x", IntLit 3)]))
+    (e (RecordUpdate (e (Var "p"), [("x", e (IntLit 3))])))
 
 (* p.x -- field projection *)
 let test_project_field () =
   check_expr "project field"
     "p.x"
-    (Project (Var "p", "x"))
+    (e (Project (e (Var "p"), "x")))
 
 (* p.x.y -- chained projection *)
 let test_project_chain () =
   check_expr "chained projection"
     "p.x.y"
-    (Project (Project (Var "p", "x"), "y"))
+    (e (Project (e (Project (e (Var "p"), "x")), "y")))
+
+(* ------------------------------------------------------------------ *)
+(* Parenthesised expressions                                            *)
+(* ------------------------------------------------------------------ *)
+
+let test_paren_grouping () =
+  check_expr "parenthesised expression"
+    "(42)"
+    (e (IntLit 42))
+
+let test_paren_var () =
+  check_expr "parenthesised var"
+    "(x)"
+    (e (Var "x"))
+
+(* ------------------------------------------------------------------ *)
+(* Comment attachment on expressions                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* 42 @# the answer #@ *)
+let test_comment_on_atom () =
+  check_expr "comment on literal"
+    "42 @# the answer #@"
+    { kind = IntLit 42; comment = Some "the answer" }
+
+(* let x = 42 @# the answer #@ in x *)
+let test_comment_on_value () =
+  check_expr "comment on let value"
+    "let x = 42 @# the answer #@ in x"
+    (e (Let { pat = p (PVar "x")
+            ; value = { kind = IntLit 42; comment = Some "the answer" }
+            ; body = e (Var "x") }))
+
+(* f(42) @# function call #@ *)
+let test_comment_on_app () =
+  check_expr "comment on application"
+    "f(42) @# function call #@"
+    { kind = App (e (Var "f"), [e (IntLit 42)]); comment = Some "function call" }
+
+(* (x) @# grouped #@ *)
+let test_comment_on_paren () =
+  check_expr "comment on parenthesised"
+    "(x) @# grouped #@"
+    { kind = Var "x"; comment = Some "grouped" }
+
+(* f(42 @# the arg #@) *)
+let test_comment_on_arg () =
+  check_expr "comment on arg"
+    "f(42 @# the arg #@)"
+    (e (App (e (Var "f"), [{ kind = IntLit 42; comment = Some "the arg" }])))
+
+(* p.x @# field access #@ *)
+let test_comment_on_project () =
+  check_expr "comment on projection"
+    "p.x @# field access #@"
+    { kind = Project (e (Var "p"), "x"); comment = Some "field access" }
 
 let () =
   Alcotest.run "Parser"
@@ -448,4 +509,16 @@ let () =
         ; Alcotest.test_case "update"            `Quick test_record_update
         ; Alcotest.test_case "project field"     `Quick test_project_field
         ; Alcotest.test_case "chained project"   `Quick test_project_chain
+        ] )
+    ; ( "parenthesised",
+        [ Alcotest.test_case "grouping"          `Quick test_paren_grouping
+        ; Alcotest.test_case "var"               `Quick test_paren_var
+        ] )
+    ; ( "comments",
+        [ Alcotest.test_case "on atom"           `Quick test_comment_on_atom
+        ; Alcotest.test_case "on let value"      `Quick test_comment_on_value
+        ; Alcotest.test_case "on app"            `Quick test_comment_on_app
+        ; Alcotest.test_case "on paren"          `Quick test_comment_on_paren
+        ; Alcotest.test_case "on arg"            `Quick test_comment_on_arg
+        ; Alcotest.test_case "on projection"     `Quick test_comment_on_project
         ] ) ]


### PR DESCRIPTION
## Summary
This PR adds support for attaching comments to AST nodes (expressions, patterns, and declarations) through a new node-attached comment syntax (`@# ... #@`). The lexer now recognizes these comments as tokens, and the parser attaches them to the nearest AST node.

## Key Changes

### Lexer (`lib/lexer.ml`)
- Added `Comment of string` token type to represent node-attached comments
- Implemented `scan_comment` function to parse `@# ... #@` delimited comments
- Comments are trimmed of leading/trailing whitespace
- Integrated comment scanning into the main tokenization loop

### AST (`lib/ast.ml`)
- Refactored `expr` from a simple variant to a record containing:
  - `desc : expr_desc` (the actual expression)
  - `comment : string option` (attached comment)
- Refactored `pattern` similarly with `pat_desc` and `pat_comment` fields
- Refactored `decl` similarly with `decl_desc` and `decl_comment` fields
- Added helper functions `expr`, `pat`, and `decl` to construct nodes with `None` comments
- Updated pretty-printers and equality functions to handle the new structure

### Parser (`lib/parser.ml`)
- Added three helper functions for comment attachment:
  - `maybe_comment_expr`: attaches comments to expressions
  - `maybe_comment_pat`: attaches comments to patterns
  - `maybe_comment_decl`: attaches comments to declarations
- Updated all expression construction sites to use `Ast.expr` wrapper and call `maybe_comment_expr`
- Updated all pattern construction sites to use `Ast.pat` wrapper and call `maybe_comment_pat`
- Updated all declaration construction sites to use `Ast.decl` wrapper and call `maybe_comment_decl`
- Fixed parenthesized expression parsing to properly return the inner expression instead of wrapping it

### Tests
- Updated `test_parser.ml` and `test_decl_parser.ml` to use new `e`, `p`, and `d` shorthand helpers for constructing test expectations
- Added comprehensive lexer tests in `test_lexer.ml` for comment tokenization:
  - Simple comments
  - Multi-word comments
  - Whitespace trimming
  - Comments between tokens
  - Multi-line comments

### Type Checker (`lib/typechecker.ml`)
- Updated pattern matching to access `e.desc` instead of matching directly on `e`

## Implementation Details
- Comments are consumed immediately after parsing a node and attached before returning
- The comment attachment is transparent to the rest of the compiler pipeline
- All existing tests were updated to work with the new node structure while maintaining the same semantic behavior

https://claude.ai/code/session_01QRPrUeCrWho46huMfMW8L9