### PR TITLE
Add program-level type checking with effect operation validation

### DIFF
--- a/docs/implementation/status.md
+++ b/docs/implementation/status.md
@@ -14,6 +14,8 @@ started in the OCaml compiler frontend.
 | Recursive-descent parser (expressions + declarations) | `lib/parser.ml` |
 | AST with node-attached comments | `lib/ast.ml` |
 | Hindley-Milner type inference with let-generalization | `lib/typechecker.ml` |
+| Program-level checking (`check_program`) — two-pass: collect decls, then check bodies against declared signatures | `lib/typechecker.ml` |
+| `perform E.op(args)` type checking against declared effect operations | `lib/typechecker.ml` |
 | Pattern matching (wildcards, vars, literals, ctors, records, or-patterns) | parser, AST |
 | Algebraic data types (`type` declarations with constructors) | parser, AST |
 | Effect declarations and `perform` / `handle` syntax | parser, AST |
@@ -29,8 +31,9 @@ started in the OCaml compiler frontend.
 
 | Feature | What exists | What is missing |
 |---------|-------------|-----------------|
-| Type checking | HM inference for core expressions (literals, let, fn, app, match, letrec) | Effect inference (deferred — returns fresh metas). Record type inference (deferred). Constructor pattern type refinement. Module-level type checking. |
-| Function type annotations | Parser accepts optional return type and effect annotations on `fn` and `DeclFn` | Design doc Section 4.3 calls for mandatory annotations at function boundaries; the parser currently makes them optional. This is intentional for incremental development. |
+| Type checking | HM inference for core expressions (literals, let, fn, app, match, letrec). `check_program` collects `DeclFn`/`DeclEffect` into envs before checking bodies. `perform E.op(args)` resolves to the declared operation, instantiates the effect's type parameters with fresh metas, unifies arg types, and returns the op's return type. | `DeclType` constructors are not registered in the value env. `DeclModule` bodies are not recursed into. Record type inference (deferred). Constructor pattern type refinement. Each `perform` instantiates the effect's type parameters independently — there is no cross-`perform` sharing via an effect row yet, so e.g. two State operations in the same function do not share their `s` type. |
+| Effect system | Declarations, `perform`, and `handle` parse and round-trip through the IR. `perform` is type-checked against declared ops. | Effect-row tracking on function types (`TyFun` has no effect slot), effect-row variables (`{E1, E2 \| ρ}`), handler-clause checking (`resume`, return-clause body vs. handled-expr result), and the constraint that every `perform`'s effect is declared in the enclosing function's effect row. |
+| Function type annotations | Parser accepts optional return type and effect annotations on `fn` and `DeclFn`. `check_program` unifies the body's inferred type against the declared return type. | Design doc Section 4.3 calls for mandatory annotations at function boundaries; the parser currently makes them optional. The declared effect set is not yet checked against the effects actually performed in the body. |
 
 ## Not Yet Implemented
 
@@ -39,7 +42,7 @@ started in the OCaml compiler frontend.
 | **Row-polymorphic records** | §4.1 (`{ l₁: τ₁ | ρ }`) | AST `type_expr` has no row variable slot. `TyName`, `TyApp`, `TyTuple`, `TyFun` are the only forms. |
 | **Recursive types** | §4.1 (`rec α . τ`) | Not in AST `type_expr`. |
 | **Effect row variables** | §4.2 (`{ E₁ | ε' }`) | AST `effect_set` is `Pure \| Effects of type_expr list` — a closed set with no row variable. |
-| **Effect type checking** | §4.2, §5 | Type checker's internal `ty` has `TyFun of ty * ty` with no effect slot. Effect inference is entirely deferred. |
+| **Effect rows on function types** | §4.2, §5 | Type checker's internal `ty` has `TyFun of ty * ty` with no effect slot. `perform` is checked for op existence and arg types, but the declared effect row on a function is not checked against the effects actually performed in its body. Handler-clause bodies (including `resume`) are not type-checked. |
 | **Module imports** | §7.3 (`import X`, `import X as Y`) | `import` is not a keyword in the lexer. Only `require effect` exists for module dependencies. |
 | **Positional shorthand** | §2.2 (`$0`, `$1` in closures) | Not in lexer or parser. |
 | **Byte literals** | §10.1 (`Char` type) | No `Char` or byte literal in AST or lexer. |

--- a/docs/implementation/status.md
+++ b/docs/implementation/status.md
@@ -16,6 +16,7 @@ started in the OCaml compiler frontend.
 | Hindley-Milner type inference with let-generalization | `lib/typechecker.ml` |
 | Program-level checking (`check_program`) — two-pass: collect decls, then check bodies against declared signatures | `lib/typechecker.ml` |
 | `perform E.op(args)` type checking against declared effect operations | `lib/typechecker.ml` |
+| `handle e with { E { op(…) => … ; return v => … } }` — op handlers checked against declared op signatures, `resume : op_return -> result`, return clause checked against the handled expression's type | `lib/typechecker.ml` |
 | Pattern matching (wildcards, vars, literals, ctors, records, or-patterns) | parser, AST |
 | Algebraic data types (`type` declarations with constructors) | parser, AST |
 | Effect declarations and `perform` / `handle` syntax | parser, AST |
@@ -32,7 +33,7 @@ started in the OCaml compiler frontend.
 | Feature | What exists | What is missing |
 |---------|-------------|-----------------|
 | Type checking | HM inference for core expressions (literals, let, fn, app, match, letrec). `check_program` collects `DeclFn`/`DeclEffect` into envs before checking bodies. `perform E.op(args)` resolves to the declared operation, instantiates the effect's type parameters with fresh metas, unifies arg types, and returns the op's return type. | `DeclType` constructors are not registered in the value env. `DeclModule` bodies are not recursed into. Record type inference (deferred). Constructor pattern type refinement. Each `perform` instantiates the effect's type parameters independently — there is no cross-`perform` sharing via an effect row yet, so e.g. two State operations in the same function do not share their `s` type. |
-| Effect system | Declarations, `perform`, and `handle` parse and round-trip through the IR. `perform` is type-checked against declared ops. | Effect-row tracking on function types (`TyFun` has no effect slot), effect-row variables (`{E1, E2 \| ρ}`), handler-clause checking (`resume`, return-clause body vs. handled-expr result), and the constraint that every `perform`'s effect is declared in the enclosing function's effect row. |
+| Effect system | Declarations, `perform`, and `handle` parse and round-trip through the IR. `perform` is type-checked against declared ops. Handler clauses are type-checked: op-handler params match the declared op, `resume` is bound with type `op_return -> result`, all op bodies and the return clause (if present) must agree on the handle's result type. | Effect-row tracking on function types (`TyFun` has no effect slot), effect-row variables (`{E1, E2 \| ρ}`), and the constraint that every `perform`'s effect is declared in the enclosing function's effect row. The handler's effect type parameters are instantiated with fresh metas that are not yet tied to the handled expression's effect row — so e.g. a `State` handler inside a function declared `! {State<Int>}` does not yet get `s := Int` from the surrounding context. |
 | Function type annotations | Parser accepts optional return type and effect annotations on `fn` and `DeclFn`. `check_program` unifies the body's inferred type against the declared return type. | Design doc Section 4.3 calls for mandatory annotations at function boundaries; the parser currently makes them optional. The declared effect set is not yet checked against the effects actually performed in the body. |
 
 ## Not Yet Implemented
@@ -42,7 +43,7 @@ started in the OCaml compiler frontend.
 | **Row-polymorphic records** | §4.1 (`{ l₁: τ₁ | ρ }`) | AST `type_expr` has no row variable slot. `TyName`, `TyApp`, `TyTuple`, `TyFun` are the only forms. |
 | **Recursive types** | §4.1 (`rec α . τ`) | Not in AST `type_expr`. |
 | **Effect row variables** | §4.2 (`{ E₁ | ε' }`) | AST `effect_set` is `Pure \| Effects of type_expr list` — a closed set with no row variable. |
-| **Effect rows on function types** | §4.2, §5 | Type checker's internal `ty` has `TyFun of ty * ty` with no effect slot. `perform` is checked for op existence and arg types, but the declared effect row on a function is not checked against the effects actually performed in its body. Handler-clause bodies (including `resume`) are not type-checked. |
+| **Effect rows on function types** | §4.2, §5 | Type checker's internal `ty` has `TyFun of ty * ty` with no effect slot. `perform` is checked for op existence and arg types, and handler clauses are checked against declared op signatures; but the declared effect row on a function is not cross-checked against the effects actually performed in its body, and a handler's effect type parameters are not yet constrained by the handled expression's effect row. |
 | **Module imports** | §7.3 (`import X`, `import X as Y`) | `import` is not a keyword in the lexer. Only `require effect` exists for module dependencies. |
 | **Positional shorthand** | §2.2 (`$0`, `$1` in closures) | Not in lexer or parser. |
 | **Byte literals** | §10.1 (`Char` type) | No `Char` or byte literal in AST or lexer. |

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -148,6 +148,10 @@ let rec unify a b =
   | TyVar x, TyVar y when x = y -> ()
   | TyFun (a1, b1), TyFun (a2, b2) ->
     unify a1 a2; unify b1 b2
+  (* Same uninstantiated meta on both sides: nothing to do. Without this
+     case, the occurs check below would spuriously fail, since a meta
+     trivially "occurs" in itself. *)
+  | TyMeta m1, TyMeta m2 when m1.id = m2.id -> ()
   | TyMeta mv, t | t, TyMeta mv ->
     if occurs_check mv t
     then failwith "Typechecker: occurs check failed (infinite type)"
@@ -420,11 +424,84 @@ let rec infer_expr_in (eenv : effect_env) (env : env) (e : expr) : ty =
       args param_tys;
     deref ret_ty
 
-  | Handle { handled; handlers = _ } ->
-    (* Handler clauses carry richer structure (operations, resume, return-clause)
-       which will be type-checked once the effect-row layer lands. For now we
-       just infer the handled expression and return its type. *)
-    infer_expr_in eenv env handled
+  | Handle { handled; handlers } ->
+    (* Type-check a linear (single-shot) handler.
+
+       Model: each handler clause consumes one effect from the handled
+       computation and produces a value of the overall `handle` result
+       type [result_ty].
+
+       - The handled expression has some value type [handled_ty]. Without a
+         return clause this is also the final result; a return clause
+         transforms [handled_ty] into [result_ty].
+       - Each op handler receives the operation's arguments at their declared
+         types (after fresh instantiation of the effect's type parameters)
+         and must produce a value of [result_ty].
+       - [resume] is bound in the op handler body with type
+         [op_return_ty -> result_ty]. Calling it continues the handled
+         computation; linear handlers resume at most once.
+
+       Effect-row tracking on function types — and the constraint that the
+       handled expression actually performs the effect being handled — is a
+       follow-on in the next layer. *)
+    let handled_ty = infer_expr_in eenv env handled in
+    let result_ty  = fresh_meta () in
+    List.iter (fun (h : effect_handler) ->
+        let scheme =
+          match List.assoc_opt h.effect_handler eenv with
+          | Some s -> s
+          | None ->
+            failwith (Printf.sprintf
+                        "Typechecker: unknown effect '%s' in handler"
+                        h.effect_handler)
+        in
+        (* Each handler clause instantiates the effect's type parameters
+           with fresh metas. These are shared across the op clauses of
+           this handler so that, e.g. for State<s>, both get: () -> s and
+           put: (s) -> Unit refer to the same s. *)
+        let subs = List.map (fun v -> (v, fresh_meta ())) scheme.eff_type_params in
+        List.iter (fun (oh : op_handler) ->
+            let op =
+              try List.find (fun o -> o.op_name = oh.op_handler_name) scheme.eff_ops
+              with Not_found ->
+                failwith (Printf.sprintf
+                            "Typechecker: effect '%s' has no operation '%s' \
+                             (in handler clause)"
+                            h.effect_handler oh.op_handler_name)
+            in
+            let op_param_tys = List.map (subst_tyvars subs) op.op_params in
+            let op_ret_ty    = subst_tyvars subs op.op_return in
+            let n_params = List.length op_param_tys in
+            let n_names  = List.length oh.op_handler_params in
+            if n_params <> n_names then
+              failwith (Printf.sprintf
+                          "Typechecker: handler for '%s.%s' binds %d param(s), \
+                           but the operation declares %d"
+                          h.effect_handler oh.op_handler_name n_names n_params);
+            (* Bind each param name to the declared op param type. *)
+            let env_params =
+              List.fold_left2 (fun acc name t -> env_extend name (mono t) acc)
+                env oh.op_handler_params op_param_tys
+            in
+            (* Bind `resume` : op_return_ty -> result_ty. Linear handlers
+               resume at most once, so we type it as a function from the
+               op's return value to the overall handle result. *)
+            let resume_ty  = TyFun (op_ret_ty, result_ty) in
+            let env_resume = env_extend "resume" (mono resume_ty) env_params in
+            let body_ty    = infer_expr_in eenv env_resume oh.op_handler_body in
+            unify body_ty result_ty)
+          h.op_handlers;
+        (* Return clause (if present) transforms the handled value into the
+           final handle result. Without one, the two types coincide. *)
+        (match h.return_handler with
+         | None ->
+           unify handled_ty result_ty
+         | Some { return_var; return_body } ->
+           let env_ret = env_extend return_var (mono handled_ty) env in
+           let body_ty = infer_expr_in eenv env_ret return_body in
+           unify body_ty result_ty))
+      handlers;
+    deref result_ty
 
   | Do stmts ->
     (* Each StmtExpr is inferred and discarded; StmtLet extends the env.

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -6,8 +6,14 @@
       declaration checker).
     - Let-generalization: the type of a let-bound expression is generalized
       over all free type variables not in the environment.
-    - Effects are ignored in this pass; only value types are inferred.
-      Effect checking is a future layer. *)
+    - Program-level checking via [check_program]: a two-pass walk collects
+      top-level effect and function declarations, then checks each function
+      body against its declared signature.
+    - Effect operations are looked up in the program's effect environment
+      and their types are instantiated at each [perform] site. Effect-row
+      tracking on function types is a future layer — this pass only checks
+      that every performed operation resolves to a declared one and that
+      argument/return types agree. *)
 
 open Ast
 
@@ -105,6 +111,29 @@ let rec free_metas acc = function
 (** Free metas in the entire environment. *)
 let env_free_metas env =
   List.concat_map (fun (_, { body; _ }) -> free_metas [] body) env
+
+(* ------------------------------------------------------------------ *)
+(* Effect environment                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(** A single operation in an effect declaration, after conversion to [ty].
+    Effect-level type parameters appear as [TyVar] and are instantiated
+    afresh at each [perform] site. *)
+type effect_op_scheme = {
+  op_name   : string;
+  op_params : ty list;
+  op_return : ty;
+}
+
+(** A declared effect: its quantified type parameters and its operations. *)
+type effect_scheme = {
+  eff_type_params : string list;
+  eff_ops         : effect_op_scheme list;
+}
+
+type effect_env = (string * effect_scheme) list
+
+let empty_effect_env : effect_env = []
 
 (* ------------------------------------------------------------------ *)
 (* Unification                                                          *)
@@ -215,9 +244,34 @@ let rec ty_of_type_expr = function
 (* Inference                                                            *)
 (* ------------------------------------------------------------------ *)
 
-(** [infer_expr env e] infers the type of expression [e] under [env].
-    Returns the inferred type. Raises [Failure] on type errors. *)
-let rec infer_expr (env : env) (e : expr) : ty =
+(** Substitute the TyVars listed in [subs] with the paired types.
+    Used to instantiate an effect operation's quantified type parameters
+    with fresh metas. *)
+let subst_tyvars subs =
+  let rec go = function
+    | TyVar v as t ->
+      (match List.assoc_opt v subs with Some u -> u | None -> t)
+    | TyCon _ as c -> c
+    | TyFun (a, b) -> TyFun (go a, go b)
+    | TyForall (v, t) ->
+      let subs' = List.filter (fun (x, _) -> x <> v) subs in
+      let rec go' = function
+        | TyVar x as t ->
+          (match List.assoc_opt x subs' with Some u -> u | None -> t)
+        | TyCon _ as c -> c
+        | TyFun (a, b) -> TyFun (go' a, go' b)
+        | TyForall (w, u) -> TyForall (w, go' u)
+        | TyMeta _ as m -> m
+      in
+      TyForall (v, go' t)
+    | TyMeta _ as m -> m
+  in
+  go
+
+(** [infer_expr_in eenv env e] infers the type of [e] under the value
+    environment [env] and effect environment [eenv]. Raises [Failure] on
+    type errors. *)
+let rec infer_expr_in (eenv : effect_env) (env : env) (e : expr) : ty =
   match e.desc with
 
   | IntLit _    -> TyCon "Int"
@@ -231,13 +285,13 @@ let rec infer_expr (env : env) (e : expr) : ty =
     instantiate scheme
 
   | Let { pat; value; body } ->
-    let ty_val = infer_expr env value in
+    let ty_val = infer_expr_in eenv env value in
     let scheme = generalize env ty_val in
     let env'   = match pat.pat_desc with
       | PVar name -> env_extend name scheme env
       | _         -> env_from_pattern env pat ty_val
     in
-    infer_expr env' body
+    infer_expr_in eenv env' body
 
   | Letrec (bindings, body) ->
     (* Compute annotated types for each binding: param types + return type -> fun_ty *)
@@ -257,14 +311,14 @@ let rec infer_expr (env : env) (e : expr) : ty =
             (fun acc p pt -> env_extend p.param_name (mono pt) acc)
             env_rec b.letrec_params param_tys
         in
-        let body_ty = infer_expr env_params b.letrec_body in
+        let body_ty = infer_expr_in eenv env_params b.letrec_body in
         unify body_ty ret_ty
       ) binding_info;
     (* Generalize and build the env for the continuation *)
     let env' = List.fold_left (fun acc (b, _, _, fun_ty) ->
         env_extend b.letrec_name (generalize env fun_ty) acc
       ) env binding_info in
-    infer_expr env' body
+    infer_expr_in eenv env' body
 
   | Fn { params; return_type; fn_body; _ } ->
     (* Replace type variable names with fresh metas so that let-generalization
@@ -291,7 +345,7 @@ let rec infer_expr (env : env) (e : expr) : ty =
         (fun acc p ty -> env_extend p.param_name (mono ty) acc)
         env params param_tys
     in
-    let body_ty = infer_expr env' fn_body in
+    let body_ty = infer_expr_in eenv env' fn_body in
     (* Unify body type with return annotation if present *)
     (match return_type with
      | Some ann_ty -> unify body_ty (freshen_type_expr ann_ty)
@@ -300,21 +354,21 @@ let rec infer_expr (env : env) (e : expr) : ty =
     List.fold_right (fun pt acc -> TyFun (pt, acc)) param_tys body_ty
 
   | App (f, args) ->
-    let f_ty   = infer_expr env f in
+    let f_ty   = infer_expr_in eenv env f in
     let ret_ty = fresh_meta () in
     (* Build the expected function type from the arguments *)
-    let arg_tys = List.map (infer_expr env) args in
+    let arg_tys = List.map (infer_expr_in eenv env) args in
     let expected = List.fold_right (fun at acc -> TyFun (at, acc)) arg_tys ret_ty in
     unify f_ty expected;
     deref ret_ty
 
   | Match { scrutinee; arms } ->
-    let _scrut_ty = infer_expr env scrutinee in
+    let _scrut_ty = infer_expr_in eenv env scrutinee in
     let result_ty = fresh_meta () in
     List.iter (fun arm ->
         (* Extend env with pattern bindings — conservative: only PVar binds *)
         let env' = env_from_pattern env arm.pattern _scrut_ty in
-        let arm_ty = infer_expr env' arm.arm_body in
+        let arm_ty = infer_expr_in eenv env' arm.arm_body in
         unify result_ty arm_ty
       ) arms;
     deref result_ty
@@ -322,35 +376,65 @@ let rec infer_expr (env : env) (e : expr) : ty =
   | Record fields ->
     (* Record types are nominal/structural — deferred until kind system.
        Infer field types for side-effects (catches unbound vars), return a fresh meta. *)
-    List.iter (fun (_, e) -> ignore (infer_expr env e)) fields;
+    List.iter (fun (_, e) -> ignore (infer_expr_in eenv env e)) fields;
     fresh_meta ()
 
   | RecordUpdate (base, fields) ->
-    let _base_ty = infer_expr env base in
-    List.iter (fun (_, e) -> ignore (infer_expr env e)) fields;
+    let _base_ty = infer_expr_in eenv env base in
+    List.iter (fun (_, e) -> ignore (infer_expr_in eenv env e)) fields;
     fresh_meta ()
 
   | Project (e, _field) ->
-    ignore (infer_expr env e);
+    ignore (infer_expr_in eenv env e);
     fresh_meta ()
 
-  | Perform _ ->
-    (* Effect typing deferred — return a fresh meta for now *)
-    fresh_meta ()
+  | Perform { effect_name; op_name; args } ->
+    let scheme =
+      match List.assoc_opt effect_name eenv with
+      | Some s -> s
+      | None ->
+        failwith (Printf.sprintf
+                    "Typechecker: unknown effect '%s' at 'perform %s.%s'"
+                    effect_name effect_name op_name)
+    in
+    let op =
+      try List.find (fun o -> o.op_name = op_name) scheme.eff_ops
+      with Not_found ->
+        failwith (Printf.sprintf
+                    "Typechecker: effect '%s' has no operation '%s'"
+                    effect_name op_name)
+    in
+    (* Each perform instantiates the effect's type parameters afresh. *)
+    let subs = List.map (fun v -> (v, fresh_meta ())) scheme.eff_type_params in
+    let param_tys = List.map (subst_tyvars subs) op.op_params in
+    let ret_ty    = subst_tyvars subs op.op_return in
+    let n_params = List.length param_tys in
+    let n_args   = List.length args in
+    if n_params <> n_args then
+      failwith (Printf.sprintf
+                  "Typechecker: effect operation '%s.%s' expects %d arg(s), got %d"
+                  effect_name op_name n_params n_args);
+    List.iter2 (fun a pt ->
+        let at = infer_expr_in eenv env a in
+        unify at pt)
+      args param_tys;
+    deref ret_ty
 
   | Handle { handled; handlers = _ } ->
-    (* Effect typing deferred — infer the handled expression's type for now *)
-    infer_expr env handled
+    (* Handler clauses carry richer structure (operations, resume, return-clause)
+       which will be type-checked once the effect-row layer lands. For now we
+       just infer the handled expression and return its type. *)
+    infer_expr_in eenv env handled
 
   | Do stmts ->
     (* Each StmtExpr is inferred and discarded; StmtLet extends the env.
        The final stmt must be a StmtExpr whose type is the block's type. *)
     let rec go env = function
       | []                         -> TyCon "Unit"
-      | [StmtExpr e]               -> infer_expr env e
-      | StmtExpr e :: rest         -> ignore (infer_expr env e); go env rest
+      | [StmtExpr e]               -> infer_expr_in eenv env e
+      | StmtExpr e :: rest         -> ignore (infer_expr_in eenv env e); go env rest
       | StmtLet { pat; value } :: rest ->
-        let ty   = infer_expr env value in
+        let ty   = infer_expr_in eenv env value in
         let env' = match pat.pat_desc with
           | PVar name -> env_extend name (generalize env ty) env
           | _         -> env_from_pattern env pat ty
@@ -360,9 +444,9 @@ let rec infer_expr (env : env) (e : expr) : ty =
     go env stmts
 
   | If { cond; then_; else_ } ->
-    unify (infer_expr env cond) (TyCon "Bool");
-    let t = infer_expr env then_ in
-    let e = infer_expr env else_ in
+    unify (infer_expr_in eenv env cond) (TyCon "Bool");
+    let t = infer_expr_in eenv env then_ in
+    let e = infer_expr_in eenv env else_ in
     unify t e;
     deref t
 
@@ -381,3 +465,90 @@ and env_from_pattern env (p : pattern) scrut_ty =
   | POr (p1, _p2) ->
     (* Both branches bind the same variables; use p1 *)
     env_from_pattern env p1 scrut_ty
+
+(** [infer_expr env e] infers the type of [e] with no effects declared.
+    Program-level inference — with declared effects in scope — uses
+    [check_program] or [infer_expr_in] directly. *)
+let infer_expr (env : env) (e : expr) : ty =
+  infer_expr_in empty_effect_env env e
+
+(* ------------------------------------------------------------------ *)
+(* Program-level checking                                              *)
+(* ------------------------------------------------------------------ *)
+
+(** Build an effect scheme from an AST effect declaration. *)
+let effect_scheme_of_decl (type_params : string list) (ops : Ast.effect_op list)
+  : effect_scheme =
+  let eff_ops = List.map (fun (o : Ast.effect_op) ->
+      { op_name   = o.effect_op_name
+      ; op_params = List.map ty_of_type_expr o.effect_op_params
+      ; op_return = ty_of_type_expr o.effect_op_return
+      }) ops
+  in
+  { eff_type_params = type_params; eff_ops }
+
+(** Build a top-level function scheme from its declared parameter types
+    and return type. Type parameters named on the declaration become the
+    scheme's bound variables so callers instantiate them with fresh metas. *)
+let fn_scheme_of_decl
+    (type_params : string list)
+    (params      : param list)
+    (return_type : type_expr option)
+  : scheme =
+  let param_tys = List.map (fun p -> ty_of_type_expr p.param_type) params in
+  let ret_ty = match return_type with
+    | Some t -> ty_of_type_expr t
+    | None   -> fresh_meta ()
+  in
+  let fun_ty = List.fold_right (fun pt acc -> TyFun (pt, acc)) param_tys ret_ty in
+  { bound = type_params; body = fun_ty }
+
+(** [check_program prog] type-checks a whole program in two passes:
+
+    Pass 1 walks every declaration and builds:
+    - the value environment, seeded with each [DeclFn]'s declared signature
+      (as a scheme over its type parameters), so that bodies can reference
+      one another regardless of declaration order;
+    - the effect environment, one entry per [DeclEffect], carrying the
+      operation signatures to be instantiated at each [perform] site.
+
+    Pass 2 walks [DeclFn]s again and type-checks each body under the seeded
+    environment extended with the function's own parameter bindings; the
+    body's inferred type is then unified with the declared return type.
+
+    [DeclType], [DeclModule], [DeclRequire]: not yet handled by this pass.
+    Constructors remain unbound in the value env and module bodies are
+    not recursed into — those are follow-on work items.
+
+    Returns the populated [(env, effect_env)] for reuse in tests and
+    downstream tooling. Raises [Failure] on type errors. *)
+let check_program (prog : program) : env * effect_env =
+  let collect (env, eenv) d =
+    match d.decl_desc with
+    | DeclEffect { effect_name; type_params; ops; _ } ->
+      let scheme = effect_scheme_of_decl type_params ops in
+      (env, (effect_name, scheme) :: eenv)
+    | DeclFn { fn_name; type_params; params; return_type; _ } ->
+      let scheme = fn_scheme_of_decl type_params params return_type in
+      ((fn_name, scheme) :: env, eenv)
+    | DeclType _ | DeclModule _ | DeclRequire _ ->
+      (env, eenv)
+  in
+  let env0, eenv0 =
+    List.fold_left collect (empty_env, empty_effect_env) prog
+  in
+  List.iter (fun d ->
+      match d.decl_desc with
+      | DeclFn { params; return_type; decl_body; _ } ->
+        let param_tys = List.map (fun p -> ty_of_type_expr p.param_type) params in
+        let body_env =
+          List.fold_left2 (fun acc p t -> env_extend p.param_name (mono t) acc)
+            env0 params param_tys
+        in
+        let body_ty = infer_expr_in eenv0 body_env decl_body in
+        (match return_type with
+         | Some t -> unify body_ty (ty_of_type_expr t)
+         | None   -> ())
+      | _ -> ())
+    prog;
+  (env0, eenv0)

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -229,6 +229,161 @@ let test_body_return_mismatch () =
       }
     |}
 
+(* ------------------------------------------------------------------ *)
+(* Handler clauses                                                      *)
+(* ------------------------------------------------------------------ *)
+
+(* A Console handler whose op returns Unit. With no return clause the
+   handled expression's type (Unit) coincides with the handle result. *)
+let test_handle_console_ok () =
+  check_program_ok "handle Console.print"
+    {|
+      effect Console {
+        print: (String) -> Unit
+      }
+
+      fn silence(body: (u: Unit) -> Unit ! {Console}) -> Unit ! pure {
+        handle body(()) with {
+          Console {
+            print(msg) => resume(())
+          }
+        }
+      }
+    |}
+
+(* A State<s> handler with a return clause that transforms the handled
+   computation's result. The effect type parameter s is instantiated once
+   per handler clause so get and put share it. *)
+let test_handle_state_with_return () =
+  check_program_ok "handle State with return"
+    {|
+      effect State<s> {
+        get: () -> s,
+        put: (s) -> Unit
+      }
+
+      fn run_state(body: (u: Unit) -> Int ! {State<Int>}) -> Int ! pure {
+        handle body(()) with {
+          State {
+            get() => resume(0)
+            put(s) => resume(())
+            return v => v
+          }
+        }
+      }
+    |}
+
+(* Handler references an unknown effect. *)
+let test_handle_unknown_effect () =
+  check_program_error "unknown effect in handler"
+    {|
+      fn go() -> Unit ! pure {
+        handle () with {
+          Nope {
+            boom() => resume(())
+          }
+        }
+      }
+    |}
+
+(* Handler clause references an unknown operation on a known effect. *)
+let test_handle_unknown_op () =
+  check_program_error "unknown op in handler"
+    {|
+      effect Console {
+        print: (String) -> Unit
+      }
+
+      fn go(body: (u: Unit) -> Unit ! {Console}) -> Unit ! pure {
+        handle body(()) with {
+          Console {
+            froodle() => resume(())
+          }
+        }
+      }
+    |}
+
+(* Handler clause binds the wrong number of parameter names. *)
+let test_handle_wrong_arity () =
+  check_program_error "handler arity mismatch"
+    {|
+      effect Console {
+        print: (String) -> Unit
+      }
+
+      fn go(body: (u: Unit) -> Unit ! {Console}) -> Unit ! pure {
+        handle body(()) with {
+          Console {
+            print() => resume(())
+          }
+        }
+      }
+    |}
+
+(* resume is called with a value of the wrong type for the op.
+   `print : (String) -> Unit`, so `resume` has type `Unit -> result`.
+   Calling `resume(42)` forces Int = Unit and fails. *)
+let test_handle_resume_wrong_type () =
+  check_program_error "resume wrong type"
+    {|
+      effect Console {
+        print: (String) -> Unit,
+        read_line: () -> String
+      }
+
+      fn bad(body: (u: Unit) -> String ! {Console}) -> String ! pure {
+        handle body(()) with {
+          Console {
+            print(msg) => resume(42)
+            read_line() => resume("hi")
+          }
+        }
+      }
+    |}
+
+(* Op handlers in the same handler must agree on the result type.
+   `get()` returns 1 (Int) — becomes the result type — but `put` returns
+   "oops" (String). *)
+let test_handle_ops_disagree () =
+  check_program_error "op handlers disagree"
+    {|
+      effect State<s> {
+        get: () -> s,
+        put: (s) -> Unit
+      }
+
+      fn bad(body: (u: Unit) -> Int ! {State<Int>}) -> Int ! pure {
+        handle body(()) with {
+          State {
+            get() => 1
+            put(s) => "oops"
+            return v => v
+          }
+        }
+      }
+    |}
+
+(* Return-clause body must have the handle's result type; here return
+   contradicts the declared Int return of the enclosing function. *)
+let test_handle_return_clause_mismatch () =
+  check_program_error "return clause body mismatch"
+    {|
+      effect State<s> {
+        get: () -> s,
+        put: (s) -> Unit
+      }
+
+      fn bad(body: (u: Unit) -> Int ! {State<Int>}) -> Int ! pure {
+        handle body(()) with {
+          State {
+            get() => resume(0)
+            put(s) => resume(())
+            return v => "not-an-int"
+          }
+        }
+      }
+    |}
+
 (* Mutual recursion across two top-level functions resolves via pass-1
    signatures registered before bodies are checked. *)
 let test_program_mutual_recursion () =
@@ -290,6 +445,16 @@ let () =
         ; Alcotest.test_case "unknown operation"         `Quick test_perform_unknown_op
         ; Alcotest.test_case "wrong arity"               `Quick test_perform_wrong_arity
         ; Alcotest.test_case "wrong arg type"            `Quick test_perform_wrong_arg_type
+        ] )
+    ; ( "handlers",
+        [ Alcotest.test_case "Console handler"           `Quick test_handle_console_ok
+        ; Alcotest.test_case "State with return clause"  `Quick test_handle_state_with_return
+        ; Alcotest.test_case "unknown effect"            `Quick test_handle_unknown_effect
+        ; Alcotest.test_case "unknown op"                `Quick test_handle_unknown_op
+        ; Alcotest.test_case "wrong arity"               `Quick test_handle_wrong_arity
+        ; Alcotest.test_case "resume wrong type"         `Quick test_handle_resume_wrong_type
+        ; Alcotest.test_case "op handlers disagree"      `Quick test_handle_ops_disagree
+        ; Alcotest.test_case "return clause mismatch"    `Quick test_handle_return_clause_mismatch
         ] )
     ; ( "program",
         [ Alcotest.test_case "body vs return mismatch"   `Quick test_body_return_mismatch

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -121,6 +121,132 @@ let test_unbound_var () =
   check_ty_error "unbound var" "x"
 
 (* ------------------------------------------------------------------ *)
+(* Effect operations and program-level checking                         *)
+(* ------------------------------------------------------------------ *)
+
+let parse_program src =
+  Axiom_lib.Parser.parse_program (Axiom_lib.Lexer.tokenize src)
+
+let check_program_of src = check_program (parse_program src)
+
+let check_program_ok label src =
+  match check_program_of src with
+  | _ -> ()
+  | exception Failure msg ->
+    Alcotest.failf "%s: unexpected type error: %s" label msg
+
+let check_program_error label src =
+  match check_program_of src with
+  | exception _ -> ()
+  | _ ->
+    Alcotest.failf "%s: expected type error but program checked cleanly" label
+
+(* A function that performs a mono-typed effect op correctly. *)
+let test_perform_console_ok () =
+  check_program_ok "Console.print"
+    {|
+      effect Console {
+        print: (String) -> Unit,
+        read_line: () -> String
+      }
+
+      fn greet() -> Unit ! {Console} {
+        perform Console.print("hi")
+      }
+    |}
+
+(* A function that reads via a generic State effect. *)
+let test_perform_state_get_ok () =
+  check_program_ok "State.get"
+    {|
+      effect State<s> {
+        get: () -> s,
+        put: (s) -> Unit
+      }
+
+      fn use_state() -> Int ! {State<Int>} {
+        do {
+          perform State.put(42);
+          perform State.get()
+        }
+      }
+    |}
+
+(* Unknown effect name *)
+let test_perform_unknown_effect () =
+  check_program_error "unknown effect"
+    {|
+      fn go() -> Unit ! pure {
+        perform Nope.boom()
+      }
+    |}
+
+(* Unknown operation on a known effect *)
+let test_perform_unknown_op () =
+  check_program_error "unknown operation"
+    {|
+      effect Console {
+        print: (String) -> Unit
+      }
+
+      fn go() -> Unit ! {Console} {
+        perform Console.froodle()
+      }
+    |}
+
+(* Wrong arity *)
+let test_perform_wrong_arity () =
+  check_program_error "wrong arity"
+    {|
+      effect Console {
+        print: (String) -> Unit
+      }
+
+      fn go() -> Unit ! {Console} {
+        perform Console.print("a", "b")
+      }
+    |}
+
+(* Wrong argument type *)
+let test_perform_wrong_arg_type () =
+  check_program_error "wrong arg type"
+    {|
+      effect Console {
+        print: (String) -> Unit
+      }
+
+      fn go() -> Unit ! {Console} {
+        perform Console.print(42)
+      }
+    |}
+
+(* Body's inferred type disagrees with the declared return type *)
+let test_body_return_mismatch () =
+  check_program_error "body vs return"
+    {|
+      fn bad() -> Int ! pure {
+        true
+      }
+    |}
+
+(* Mutual recursion across two top-level functions resolves via pass-1
+   signatures registered before bodies are checked. *)
+let test_program_mutual_recursion () =
+  check_program_ok "mutual recursion"
+    {|
+      fn even(n: Int) -> Bool ! pure {
+        if eq(n, 0) { true } else { odd(sub(n, 1)) }
+      }
+
+      fn odd(n: Int) -> Bool ! pure {
+        if eq(n, 0) { false } else { even(sub(n, 1)) }
+      }
+
+      fn eq(a: Int, b: Int) -> Bool ! pure { true }
+      fn sub(a: Int, b: Int) -> Int ! pure { a }
+    |}
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -156,4 +282,16 @@ let () =
         ] )
     ; ( "errors",
         [ Alcotest.test_case "unbound var"       `Quick test_unbound_var
+        ] )
+    ; ( "effects",
+        [ Alcotest.test_case "perform Console.print"     `Quick test_perform_console_ok
+        ; Alcotest.test_case "perform State.get"         `Quick test_perform_state_get_ok
+        ; Alcotest.test_case "unknown effect"            `Quick test_perform_unknown_effect
+        ; Alcotest.test_case "unknown operation"         `Quick test_perform_unknown_op
+        ; Alcotest.test_case "wrong arity"               `Quick test_perform_wrong_arity
+        ; Alcotest.test_case "wrong arg type"            `Quick test_perform_wrong_arg_type
+        ] )
+    ; ( "program",
+        [ Alcotest.test_case "body vs return mismatch"   `Quick test_body_return_mismatch
+        ; Alcotest.test_case "mutual recursion"          `Quick test_program_mutual_recursion
         ] ) ]


### PR DESCRIPTION
## Summary

This PR implements program-level type checking via a new `check_program` function that validates effect declarations and function bodies against their declared signatures. It also adds runtime type checking for `perform` expressions to ensure they reference declared effect operations with correct argument types and arities.

## Key Changes

- **Effect environment infrastructure**: Added `effect_op_scheme`, `effect_scheme`, and `effect_env` types to represent declared effects and their operations with quantified type parameters.

- **Program-level checking (`check_program`)**: Implemented a two-pass algorithm:
  - Pass 1: Collects all top-level effect and function declarations, building the effect environment and seeding the value environment with function signatures (enabling mutual recursion)
  - Pass 2: Type-checks each function body against its declared signature, unifying inferred body types with declared return types

- **Effect operation type checking**: Enhanced `infer_expr` to validate `perform` expressions:
  - Looks up the effect and operation in the effect environment
  - Instantiates the effect's type parameters with fresh metas at each perform site
  - Validates argument count and types against the operation signature
  - Returns the operation's return type (with instantiated type parameters)

- **Refactored inference**: Renamed core inference to `infer_expr_in` to accept both value and effect environments; kept `infer_expr` as a wrapper for backward compatibility with no effects declared.

- **Comprehensive test coverage**: Added 8 new tests covering:
  - Monomorphic effect operations (Console.print)
  - Polymorphic effect operations (State<s>)
  - Error cases: unknown effects, unknown operations, wrong arity, wrong argument types
  - Function body return type mismatches
  - Mutual recursion across top-level functions

## Implementation Details

- Effect type parameters are instantiated afresh at each `perform` site via a new `subst_tyvars` helper that substitutes type variables in effect operation signatures.
- Function schemes are built from declared type parameters and parameter/return type annotations, allowing callers to instantiate them with fresh metas.
- The two-pass design ensures all declarations are visible before any body is checked, supporting forward references and mutual recursion.
- Handler clauses (`Handle`) are not yet fully type-checked; the pass infers the handled expression's type pending the effect-row layer.

https://claude.ai/code/session_01RtWaHJWXA1TzeAyoejbDLF