### PR TITLE
Add support for parameterized type applications (generics)

### DIFF
--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -36,6 +36,7 @@ type ty =
   | TyForall of string * ty     (** forall a. T  (generalized) *)
   | TyMeta   of meta_var        (** unification variable *)
   | TyRecord of (string * ty) list (** structural record type: {f1: T1, f2: T2, ...} *)
+  | TyApp    of string * ty list (** parameterized type: Option<Int>, List<a>, Map<K,V> *)
 
 and meta_var = {
   id       : int;
@@ -82,6 +83,11 @@ let rec pp_ty fmt = function
       (Format.pp_print_list ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
          (fun fmt (name, ty) -> Format.fprintf fmt "%s: %a" name pp_ty ty))
       sorted
+  | TyApp (name, args) ->
+    Format.fprintf fmt "%s<%a>" name
+      (Format.pp_print_list ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+         pp_ty)
+      args
 
 and pp_row fmt = function
   | RPure -> Format.pp_print_string fmt "pure"
@@ -132,6 +138,9 @@ let rec equal_ty a b = match a, b with
     let fa' = sort fa and fb' = sort fb in
     List.length fa' = List.length fb'
     && List.for_all2 (fun (na, ta) (nb, tb) -> na = nb && equal_ty ta tb) fa' fb'
+  | TyApp (n1, a1), TyApp (n2, a2) ->
+    n1 = n2 && List.length a1 = List.length a2
+    && List.for_all2 equal_ty a1 a2
   | _, _ -> false
 
 and equal_row a b = match a, b with
@@ -213,6 +222,8 @@ let rec free_metas acc = function
      | Some t -> free_metas acc t)
   | TyRecord fields ->
     List.fold_left (fun acc (_, t) -> free_metas acc t) acc fields
+  | TyApp (_, args) ->
+    List.fold_left free_metas acc args
 
 and free_row_ty_metas acc = function
   | RPure -> acc
@@ -237,6 +248,8 @@ let rec free_row_metas acc = function
      | Some t -> free_row_metas acc t)
   | TyRecord fields ->
     List.fold_left (fun acc (_, t) -> free_row_metas acc t) acc fields
+  | TyApp (_, args) ->
+    List.fold_left free_row_metas acc args
 
 and free_row_metas_row acc = function
   | RPure -> acc
@@ -313,6 +326,14 @@ let rec unify a b =
                         "Typechecker: record field name mismatch: '%s' vs '%s'" na nb)
           else unify ta tb)
         fa' fb'
+  | TyApp (n1, a1), TyApp (n2, a2) ->
+    if n1 <> n2 then
+      failwith (Format.asprintf
+                  "Typechecker: cannot unify %a with %a" pp_ty (TyApp (n1, a1)) pp_ty (TyApp (n2, a2)));
+    if List.length a1 <> List.length a2 then
+      failwith (Format.asprintf
+                  "Typechecker: type constructor %s applied to wrong number of arguments" n1);
+    List.iter2 unify a1 a2
   | a, b ->
     failwith (Format.asprintf "Typechecker: cannot unify %a with %a" pp_ty a pp_ty b)
 
@@ -388,6 +409,7 @@ and subst_ty subs = function
     TyForall (v, subst_ty subs' t)
   | TyMeta _ as m -> m
   | TyRecord fields -> TyRecord (List.map (fun (n, t) -> (n, subst_ty subs t)) fields)
+  | TyApp (name, args) -> TyApp (name, List.map (subst_ty subs) args)
 
 (** Replace all bound type variables in a scheme with fresh metas, and
     re-open every TyFun row along the way with a fresh row meta tail.
@@ -432,6 +454,7 @@ let generalize env ty =
       | TyFun (a, b, r) -> TyFun (go a, go b, go_row r)
       | TyForall (v, u) -> TyForall (v, go u)
       | TyRecord fields -> TyRecord (List.map (fun (n, t) -> (n, go t)) fields)
+      | TyApp (name, args) -> TyApp (name, List.map go args)
     and go_row = function
       | RPure -> RPure
       | RCons (e, rest) ->
@@ -463,7 +486,7 @@ let rec ty_of_type_expr = function
   | TyName s when String.length s > 0 && s.[0] >= 'a' && s.[0] <= 'z' ->
     TyVar s
   | TyName s  -> TyCon s
-  | TyApp (s, _args) -> TyCon s
+  | TyApp (s, args) -> TyApp (s, List.map ty_of_type_expr args)
   | TyTuple _ -> fresh_meta ()    (* tuple types deferred *)
   | TyFun (param_tys, ret, eff) ->
     let ret_ty = ty_of_type_expr ret in
@@ -521,6 +544,7 @@ let rec subst_tyvars subs t =
       TyForall (v, subst_tyvars subs' t)
     | TyMeta _ as m -> m
     | TyRecord fields -> TyRecord (List.map (fun (n, t) -> (n, go t)) fields)
+    | TyApp (name, args) -> TyApp (name, List.map go args)
   and go_row = function
     | RPure -> RPure
     | RCons (e, rest) ->
@@ -600,7 +624,7 @@ let rec infer_expr_in (eenv : effect_env) (env : env) (ambient : row) (e : expr)
        (e.g. 'a') maps to the same meta across all param annotations. *)
     let tv_table : (string * ty) list ref = ref [] in
     let freshen_type_expr ty_expr =
-      let go = function
+      let rec go = function
         | TyName s when String.length s > 0 && s.[0] >= 'a' && s.[0] <= 'z' ->
           (match List.assoc_opt s !tv_table with
            | Some m -> m
@@ -608,7 +632,7 @@ let rec infer_expr_in (eenv : effect_env) (env : env) (ambient : row) (e : expr)
              let m = fresh_meta () in
              tv_table := (s, m) :: !tv_table; m)
         | TyName s            -> TyCon s
-        | TyApp (s, _)        -> TyCon s
+        | TyApp (s, args)     -> TyApp (s, List.map go args)
         | TyTuple _ | TyFun _ -> fresh_meta ()
       in
       go ty_expr
@@ -976,7 +1000,10 @@ let ctor_scheme_of_type
     (type_params : string list)
     (ctor        : Ast.ctor_decl)
   : scheme =
-  let ret_ty    = TyCon type_name in
+  let ret_ty =
+    if type_params = [] then TyCon type_name
+    else TyApp (type_name, List.map (fun v -> TyVar v) type_params)
+  in
   let param_tys = List.map ty_of_type_expr ctor.ctor_params in
   let body = match List.rev param_tys with
     | [] -> ret_ty

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -16,6 +16,7 @@ let rec strip_rows = function
   | TyMeta { inst = Some t; _ } -> strip_rows t
   | TyMeta _ as m -> m
   | TyRecord fields -> TyRecord (List.map (fun (n, t) -> (n, strip_rows t)) fields)
+  | TyApp (name, args) -> TyApp (name, List.map strip_rows args)
 
 let infer_of src =
   let tokens = Axiom_lib.Lexer.tokenize src in
@@ -661,7 +662,7 @@ let test_decl_type_parametric_ctor () =
     {|
       type Option<a> = | Some(a) | None
 
-      fn get_or_zero(opt: Option) -> Int ! pure {
+      fn get_or_zero(opt: Option<Int>) -> Int ! pure {
         match opt with {
           | Some(x) => x
           | None    => 0
@@ -675,7 +676,7 @@ let test_decl_type_ctor_pattern_arity () =
     {|
       type Option<a> = | Some(a) | None
 
-      fn bad(opt: Option) -> Int ! pure {
+      fn bad(opt: Option<Int>) -> Int ! pure {
         match opt with {
           | Some(x, y) => 0
           | None       => 1
@@ -838,6 +839,86 @@ let test_program_record_pattern_unknown_field () =
     |}
 
 (* ------------------------------------------------------------------ *)
+(* Parametric type application                                          *)
+(* ------------------------------------------------------------------ *)
+
+(* Option<Int> and Option<Bool> are distinct types. *)
+let test_tyapp_distinct_params () =
+  check_program_error "Option<Int> ≠ Option<Bool>"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn bad(x: Option<Int>) -> Option<Bool> ! pure { x }
+    |}
+
+(* Constructing Some(42) where Option<Bool> is expected is a type error. *)
+let test_tyapp_ctor_wrong_param () =
+  check_program_error "Some(42) where Option<Bool> expected"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn bad() -> Option<Bool> ! pure { Some(42) }
+    |}
+
+(* Round-trip through a parameterized return type. *)
+let test_tyapp_return_type () =
+  check_program_ok "Option<Int> return type"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn wrap(n: Int) -> Option<Int> ! pure { Some(n) }
+    |}
+
+(* Nested type application: Option<Option<Int>>. *)
+let test_tyapp_nested () =
+  check_program_ok "Option<Option<Int>>"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn double_wrap(n: Int) -> Option<Option<Int>> ! pure {
+        Some(Some(n))
+      }
+    |}
+
+(* Two-parameter type: Result<a, e>. *)
+let test_tyapp_two_params () =
+  check_program_ok "Result<Int, String>"
+    {|
+      type Result<a, e> = | Ok(a) | Err(e)
+
+      fn make_ok(n: Int) -> Result<Int, String> ! pure { Ok(n) }
+      fn make_err(s: String) -> Result<Int, String> ! pure { Err(s) }
+    |}
+
+(* Mixing Ok and Err branches in a match must agree on the result type. *)
+let test_tyapp_result_match () =
+  check_program_ok "match Result arms"
+    {|
+      type Result<a, e> = | Ok(a) | Err(e)
+
+      fn unwrap_or(r: Result<Int, String>, default: Int) -> Int ! pure {
+        match r with {
+          | Ok(x)  => x
+          | Err(_) => default
+        }
+      }
+    |}
+
+(* Using the wrong type in an Ok arm is a type error. *)
+let test_tyapp_result_arm_mismatch () =
+  check_program_error "Result arm type mismatch"
+    {|
+      type Result<a, e> = | Ok(a) | Err(e)
+
+      fn bad(r: Result<Int, String>) -> Int ! pure {
+        match r with {
+          | Ok(x)  => x
+          | Err(s) => s
+        }
+      }
+    |}
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -941,4 +1022,13 @@ let () =
         ; Alcotest.test_case "program record pattern"    `Quick test_program_record_pattern
         ; Alcotest.test_case "program record pattern types" `Quick test_program_record_pattern_types
         ; Alcotest.test_case "program pattern unknown field" `Quick test_program_record_pattern_unknown_field
+        ] )
+    ; ( "parametric types",
+        [ Alcotest.test_case "distinct params"           `Quick test_tyapp_distinct_params
+        ; Alcotest.test_case "ctor wrong param"          `Quick test_tyapp_ctor_wrong_param
+        ; Alcotest.test_case "Option<Int> return"        `Quick test_tyapp_return_type
+        ; Alcotest.test_case "nested TyApp"              `Quick test_tyapp_nested
+        ; Alcotest.test_case "two-param Result"          `Quick test_tyapp_two_params
+        ; Alcotest.test_case "Result match arms"         `Quick test_tyapp_result_match
+        ; Alcotest.test_case "Result arm mismatch"       `Quick test_tyapp_result_arm_mismatch
         ] ) ]


### PR DESCRIPTION
## Summary
This PR adds support for parameterized type applications (generics) to the type system. Previously, the type checker could not properly handle generic types like `Option<Int>` or `Result<Int, String>`. This change introduces a new `TyApp` type constructor that represents type applications with explicit type arguments.

## Key Changes

- **New type constructor**: Added `TyApp of string * ty list` to represent parameterized types (e.g., `Option<Int>`, `List<a>`, `Map<K,V>`)

- **Type operations**: Implemented support for `TyApp` across all type manipulation functions:
  - Pretty-printing (`pp_ty`) now formats type applications as `name<arg1, arg2, ...>`
  - Type equality (`equal_ty`) checks both the type name and argument types
  - Free variable collection (`free_metas`, `free_row_metas`) recursively processes type arguments
  - Unification (`unify`) validates matching type constructors and argument counts
  - Substitution (`subst_ty`, `subst_tyvars`) recursively processes arguments
  - Generalization properly handles type applications

- **Parser integration**: Updated `ty_of_type_expr` to convert parsed type applications into `TyApp` nodes instead of discarding arguments

- **Constructor schemes**: Modified `ctor_scheme_of_type` to generate proper return types for parameterized type constructors (e.g., `Some` in `Option<a>` now returns `Option<a>` instead of just `Option`)

- **Test coverage**: Added comprehensive test suite with 7 new test cases covering:
  - Distinct parameterized types (`Option<Int>` ≠ `Option<Bool>`)
  - Constructor type checking with parameters
  - Nested type applications (`Option<Option<Int>>`)
  - Multi-parameter types (`Result<a, e>`)
  - Pattern matching with parameterized types

- **Test fixes**: Updated existing tests to use properly parameterized type annotations (e.g., `Option<Int>` instead of bare `Option`)

## Implementation Details

The implementation ensures that type parameters are properly tracked through unification and substitution, enabling the type checker to catch errors like constructing `Some(42)` when `Option<Bool>` is expected. The `strip_rows` utility function was also updated to handle `TyApp` nodes during type simplification.

https://claude.ai/code/session_01CRguysRXr4VQ4K4b4R3xcZ