### PR TITLE
feat(#16): implement module import declarations

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -498,6 +498,10 @@ and decl_desc =
       body        : decl list;
     }
   | DeclRequire of type_expr
+  | DeclImport of {
+      module_path : string;
+      alias       : string option;
+    }
 
 (** Build a declaration node with no comment. *)
 let decl k = { decl_desc = k; decl_comment = None }
@@ -564,6 +568,10 @@ and pp_decl_desc fmt = function
          pp_decl) body
   | DeclRequire t ->
     Format.fprintf fmt "Require(%a)" pp_type_expr t
+  | DeclImport { module_path; alias } ->
+    (match alias with
+     | None   -> Format.fprintf fmt "Import(%s)" module_path
+     | Some a -> Format.fprintf fmt "Import(%s as %s)" module_path a)
 
 (* ------------------------------------------------------------------ *)
 (* Equality for declarations                                            *)
@@ -608,6 +616,8 @@ and equal_decl_desc a b = match a, b with
     && List.length a.body = List.length b.body
     && List.for_all2 equal_decl a.body b.body
   | DeclRequire a, DeclRequire b -> equal_type_expr a b
+  | DeclImport a, DeclImport b ->
+    a.module_path = b.module_path && a.alias = b.alias
   | _, _ -> false
 
 let equal_program a b =

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -12,7 +12,7 @@ type token =
   (* Keywords *)
   | Let | In | Fn | Pub | Type | Module | Require | Effect
   | Perform | Handle | With | Match | Do | Resume | Letrec
-  | If | Else | Return
+  | If | Else | Return | Import | As
   (* Built-in value keywords *)
   | Pure | True | False
   (* Identifiers *)
@@ -67,6 +67,8 @@ let pp_token fmt = function
   | If       -> Format.pp_print_string fmt "If"
   | Else     -> Format.pp_print_string fmt "Else"
   | Return   -> Format.pp_print_string fmt "Return"
+  | Import   -> Format.pp_print_string fmt "Import"
+  | As       -> Format.pp_print_string fmt "As"
   | Pure     -> Format.pp_print_string fmt "Pure"
   | True     -> Format.pp_print_string fmt "True"
   | False    -> Format.pp_print_string fmt "False"
@@ -126,6 +128,8 @@ let keyword_of_string = function
   | "if"      -> Some If
   | "else"    -> Some Else
   | "return"  -> Some Return
+  | "import"  -> Some Import
+  | "as"      -> Some As
   | "pure"    -> Some Pure
   | "true"    -> Some True
   | "false"   -> Some False

--- a/lib/node_decoding.ml
+++ b/lib/node_decoding.ml
@@ -446,6 +446,12 @@ let rec decode_decl lookup hash : decl =
       let decl_comment = get_comment cur in
       (DeclRequire ty, decl_comment)
 
+    | t when t = tag_decl_import ->
+      let module_path = get_str cur in
+      let alias = get_opt cur get_str in
+      let decl_comment = get_comment cur in
+      (DeclImport { module_path; alias }, decl_comment)
+
     | _ -> failwith (Printf.sprintf "Node_decoding: unknown declaration tag 0x%02x" tag)
   in
   { decl_desc; decl_comment }

--- a/lib/node_encoding.ml
+++ b/lib/node_encoding.ml
@@ -412,6 +412,13 @@ let rec encode_decl store (d : decl) : bytes =
         put_type_expr buf ty;
         put_comment buf d.decl_comment)
 
+  | DeclImport { module_path; alias } ->
+    build_node store ~tag:tag_decl_import ~children:[]
+      ~write_inline:(fun buf ->
+        put_str buf module_path;
+        put_opt buf put_str alias;
+        put_comment buf d.decl_comment)
+
 (* ================================================================== *)
 (* Program encoder                                                     *)
 (* ================================================================== *)

--- a/lib/node_tag.ml
+++ b/lib/node_tag.ml
@@ -39,6 +39,7 @@ let tag_decl_type     = 0x51
 let tag_decl_effect   = 0x52
 let tag_decl_module   = 0x53
 let tag_decl_require  = 0x54
+let tag_decl_import   = 0x56
 let tag_program       = 0x55
 
 (* ================================================================== *)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -719,6 +719,26 @@ let rec parse_decl (st : state) : Ast.decl =
       let t = parse_type_expr st in
       Ast.decl (DeclRequire t)
 
+    | Some Import ->
+      advance st;
+      let module_path = match peek st with
+        | Some (Ident s) -> advance st; s
+        | Some t ->
+          failwith (Format.asprintf "Parser: expected module name after 'import', got %a" pp_token t)
+        | None -> failwith "Parser: expected module name after 'import'"
+      in
+      let alias = match peek st with
+        | Some As ->
+          advance st;
+          (match peek st with
+           | Some (Ident s) -> advance st; Some s
+           | Some t ->
+             failwith (Format.asprintf "Parser: expected alias after 'as', got %a" pp_token t)
+           | None -> failwith "Parser: expected alias after 'as'")
+        | _ -> None
+      in
+      Ast.decl (DeclImport { module_path; alias })
+
     | Some t ->
       failwith (Format.asprintf "Parser: expected declaration, got %a" pp_token t)
     | None ->

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -719,22 +719,36 @@ let rec infer_expr_in (eenv : effect_env) (env : env) (ambient : row) (e : expr)
                    "Typechecker: record update on non-record type %a" pp_ty t))
 
   | Project (e, field) ->
-    let e_ty = infer_expr_in eenv env ambient e in
-    (match deref e_ty with
-     | TyRecord fields ->
-       (match List.assoc_opt field fields with
-        | Some field_ty -> deref field_ty
-        | None ->
-          failwith (Printf.sprintf
-                      "Typechecker: record has no field '%s'" field))
-     | TyMeta _ ->
-       (* Base type not yet determined; constrain it to contain this field *)
-       let field_ty = fresh_meta () in
-       unify e_ty (TyRecord [(field, field_ty)]);
-       deref field_ty
-     | t ->
-       failwith (Format.asprintf
-                   "Typechecker: field projection applied to non-record type %a" pp_ty t))
+    (* Check for module-qualified access: if e is a bare Var whose name
+       matches a known module, look up "module.field" directly in the env
+       rather than trying to type-check the Var as a standalone value. *)
+    let module_qualified_ty =
+      match e.desc with
+      | Var possible_module ->
+        let qualified = possible_module ^ "." ^ field in
+        (match List.assoc_opt qualified env with
+         | Some scheme -> Some (instantiate scheme)
+         | None        -> None)
+      | _ -> None
+    in
+    (match module_qualified_ty with
+     | Some ty -> ty
+     | None ->
+       let e_ty = infer_expr_in eenv env ambient e in
+       (match deref e_ty with
+        | TyRecord fields ->
+          (match List.assoc_opt field fields with
+           | Some field_ty -> deref field_ty
+           | None ->
+             failwith (Printf.sprintf
+                         "Typechecker: record has no field '%s'" field))
+        | TyMeta _ ->
+          let field_ty = fresh_meta () in
+          unify e_ty (TyRecord [(field, field_ty)]);
+          deref field_ty
+        | t ->
+          failwith (Format.asprintf
+                      "Typechecker: field projection applied to non-record type %a" pp_ty t)))
 
   | Perform { effect_name; op_name; args } ->
     let scheme =
@@ -1015,6 +1029,39 @@ let ctor_scheme_of_type
   in
   { bound = type_params; body }
 
+(** A module registry maps module names to the bare (env, effect_env) of
+    their direct declarations, keyed by unqualified name. Used by
+    [check_program] to resolve [DeclImport] and to register qualified names
+    for [DeclModule]. *)
+type module_registry = (string * (env * effect_env)) list
+
+(** Build the module registry by scanning [prog] for [DeclModule] nodes.
+    Only top-level modules are registered; nested modules are not. *)
+let build_module_registry (prog : program) : module_registry =
+  List.filter_map (fun d ->
+    match d.decl_desc with
+    | DeclModule { module_name; body; _ } ->
+      let collect_body (env, eenv) b =
+        match b.decl_desc with
+        | DeclEffect { effect_name; type_params; ops; _ } ->
+          let scheme = effect_scheme_of_decl type_params ops in
+          (env, (effect_name, scheme) :: eenv)
+        | DeclFn { fn_name; type_params; params; return_type; effects; _ } ->
+          let scheme = fn_scheme_of_decl type_params params return_type effects in
+          ((fn_name, scheme) :: env, eenv)
+        | DeclType { type_name; type_params; ctors; _ } ->
+          let env' = List.fold_left (fun acc ctor ->
+              env_extend ctor.Ast.ctor_name
+                (ctor_scheme_of_type type_name type_params ctor) acc
+            ) env ctors in
+          (env', eenv)
+        | _ -> (env, eenv)
+      in
+      let mod_env, mod_eenv = List.fold_left collect_body ([], []) body in
+      Some (module_name, (mod_env, mod_eenv))
+    | _ -> None
+  ) prog
+
 (** [check_program prog] type-checks a whole program in two passes:
 
     Pass 1 walks every declaration and builds:
@@ -1040,6 +1087,19 @@ let ctor_scheme_of_type
     Returns the populated [(env, effect_env)] for reuse in tests and
     downstream tooling. Raises [Failure] on type errors. *)
 let check_program (prog : program) : env * effect_env =
+  let module_registry = build_module_registry prog in
+  (* [add_qualified prefix mod_env mod_eenv env eenv] folds [mod_env] and
+     [mod_eenv] into [env] and [eenv], prepending [prefix ^ "."] to each key. *)
+  let add_qualified prefix mod_env mod_eenv env eenv =
+    let qualify name = prefix ^ "." ^ name in
+    let env' = List.fold_left
+        (fun acc (name, scheme) -> env_extend (qualify name) scheme acc)
+        env mod_env in
+    let eenv' = List.fold_left
+        (fun acc (name, scheme) -> (qualify name, scheme) :: acc)
+        eenv mod_eenv in
+    (env', eenv')
+  in
   let rec collect (env, eenv) d =
     match d.decl_desc with
     | DeclEffect { effect_name; type_params; ops; _ } ->
@@ -1055,8 +1115,23 @@ let check_program (prog : program) : env * effect_env =
             acc
         ) env ctors in
       (env', eenv)
-    | DeclModule { body; _ } ->
-      List.fold_left collect (env, eenv) body
+    | DeclModule { module_name; body; _ } ->
+      (* Fold body into the flat env with bare names (existing behaviour). *)
+      let env', eenv' = List.fold_left collect (env, eenv) body in
+      (* Also register each declaration under module_name.name so callers
+         can access them via qualified syntax (module_name.fn). *)
+      (match List.assoc_opt module_name module_registry with
+       | None -> (env', eenv')
+       | Some (mod_env, mod_eenv) ->
+         add_qualified module_name mod_env mod_eenv env' eenv')
+    | DeclImport { module_path; alias } ->
+      let prefix = match alias with Some a -> a | None -> module_path in
+      (match List.assoc_opt module_path module_registry with
+       | None ->
+         failwith (Printf.sprintf
+                     "Typechecker: unknown module '%s' in import" module_path)
+       | Some (mod_env, mod_eenv) ->
+         add_qualified prefix mod_env mod_eenv env eenv)
     | DeclRequire _ ->
       (env, eenv)
   in
@@ -1081,7 +1156,7 @@ let check_program (prog : program) : env * effect_env =
        | None   -> ())
     | DeclModule { body; _ } ->
       List.iter check_decl body
-    | _ -> ()
+    | DeclImport _ | DeclRequire _ | DeclEffect _ | DeclType _ -> ()
   in
   List.iter check_decl prog;
   (env0, eenv0)

--- a/test/test_decl_parser.ml
+++ b/test/test_decl_parser.ml
@@ -172,6 +172,22 @@ let test_require_decl () =
     (decl (DeclRequire (TyName "Log")))
 
 (* ------------------------------------------------------------------ *)
+(* import declarations                                                  *)
+(* ------------------------------------------------------------------ *)
+
+(* import json_parser *)
+let test_import_decl_bare () =
+  check_decl "import bare"
+    "import json_parser"
+    (decl (DeclImport { module_path = "json_parser"; alias = None }))
+
+(* import http_client as http *)
+let test_import_decl_alias () =
+  check_decl "import with alias"
+    "import http_client as http"
+    (decl (DeclImport { module_path = "http_client"; alias = Some "http" }))
+
+(* ------------------------------------------------------------------ *)
 (* Multi-declaration programs                                           *)
 (* ------------------------------------------------------------------ *)
 
@@ -234,6 +250,10 @@ let () =
         ] )
     ; ( "require",
         [ Alcotest.test_case "Log"             `Quick test_require_decl
+        ] )
+    ; ( "import",
+        [ Alcotest.test_case "bare"            `Quick test_import_decl_bare
+        ; Alcotest.test_case "with alias"      `Quick test_import_decl_alias
         ] )
     ; ( "program",
         [ Alcotest.test_case "two fns"         `Quick test_program_two_fns

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -839,6 +839,90 @@ let test_program_record_pattern_unknown_field () =
     |}
 
 (* ------------------------------------------------------------------ *)
+(* Module imports                                                       *)
+(* ------------------------------------------------------------------ *)
+
+(* Functions declared in a module are callable via module.fn syntax. *)
+let test_import_qualified_access () =
+  check_program_ok "module qualified access"
+    {|
+      module math {
+        fn add(a: Int, b: Int) -> Int ! pure { a }
+      }
+
+      fn use_it() -> Int ! pure {
+        math.add(1, 2)
+      }
+    |}
+
+(* import M makes M.fn available under M.fn. *)
+let test_import_bare () =
+  check_program_ok "import bare"
+    {|
+      module math {
+        fn add(a: Int, b: Int) -> Int ! pure { a }
+      }
+
+      import math
+
+      fn use_it() -> Int ! pure {
+        math.add(1, 2)
+      }
+    |}
+
+(* import M as alias makes M's functions available as alias.fn. *)
+let test_import_alias () =
+  check_program_ok "import with alias"
+    {|
+      module math {
+        fn add(a: Int, b: Int) -> Int ! pure { a }
+      }
+
+      import math as m
+
+      fn use_it() -> Int ! pure {
+        m.add(1, 2)
+      }
+    |}
+
+(* Importing an unknown module is a type error. *)
+let test_import_unknown_module () =
+  check_program_error "import unknown module"
+    {|
+      import no_such_module
+
+      fn use_it() -> Int ! pure { 42 }
+    |}
+
+(* A module's function called via qualified name with wrong arg type fails. *)
+let test_import_qualified_wrong_type () =
+  check_program_error "qualified call wrong arg type"
+    {|
+      module math {
+        fn add(a: Int, b: Int) -> Int ! pure { a }
+      }
+
+      fn bad() -> Int ! pure {
+        math.add(true, 2)
+      }
+    |}
+
+(* import before module definition (order-independent via pre-pass). *)
+let test_import_before_definition () =
+  check_program_ok "import before definition"
+    {|
+      import math
+
+      fn use_it() -> Int ! pure {
+        math.add(1, 2)
+      }
+
+      module math {
+        fn add(a: Int, b: Int) -> Int ! pure { a }
+      }
+    |}
+
+(* ------------------------------------------------------------------ *)
 (* Parametric type application                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -1022,6 +1106,14 @@ let () =
         ; Alcotest.test_case "program record pattern"    `Quick test_program_record_pattern
         ; Alcotest.test_case "program record pattern types" `Quick test_program_record_pattern_types
         ; Alcotest.test_case "program pattern unknown field" `Quick test_program_record_pattern_unknown_field
+        ] )
+    ; ( "imports",
+        [ Alcotest.test_case "qualified access"          `Quick test_import_qualified_access
+        ; Alcotest.test_case "import bare"               `Quick test_import_bare
+        ; Alcotest.test_case "import alias"              `Quick test_import_alias
+        ; Alcotest.test_case "unknown module"            `Quick test_import_unknown_module
+        ; Alcotest.test_case "qualified wrong type"      `Quick test_import_qualified_wrong_type
+        ; Alcotest.test_case "import before definition"  `Quick test_import_before_definition
         ] )
     ; ( "parametric types",
         [ Alcotest.test_case "distinct params"           `Quick test_tyapp_distinct_params


### PR DESCRIPTION
Adds `import <module>` and `import <module> as <alias>` syntax throughout the compiler stack:

- Lexer: new `Import` and `As` token kinds
- AST: new `DeclImport { module_path; alias }` declaration variant
- Parser: parses import declarations with optional alias
- Typechecker: module registry pre-pass; `DeclImport` injects qualified names into scope; `Project` intercepts `module.fn` lookups before falling through to record-field access
- Binary IR: `tag_decl_import = 0x56` + encode/decode cases in `node_encoding.ml` and `node_decoding.ml`
- Tests: 2 new parser tests, 6 new typechecker tests (84 total)

https://claude.ai/code/session_01CRguysRXr4VQ4K4b4R3xcZ