### PR TITLE
Add exhaustiveness checking for pattern matches

### DIFF
--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -288,6 +288,11 @@ type effect_env = (string * effect_scheme) list
 
 let empty_effect_env : effect_env = []
 
+(** Maps each declared type name to its constructor names.
+    Populated by [check_program] before inference begins; used by
+    [check_match_exhaustive] to verify pattern coverage for ADTs. *)
+let type_ctor_env : (string * string list) list ref = ref []
+
 (* ------------------------------------------------------------------ *)
 (* Unification                                                          *)
 (* ------------------------------------------------------------------ *)
@@ -526,6 +531,69 @@ and effect_inst_of_type_expr = function
                 Ast.pp_type_expr t)
 
 (* ------------------------------------------------------------------ *)
+(* Exhaustiveness checking                                              *)
+(* ------------------------------------------------------------------ *)
+
+let rec flatten_or_pat p =
+  match p.pat_desc with
+  | POr (p1, p2) -> flatten_or_pat p1 @ flatten_or_pat p2
+  | _ -> [p]
+
+(** [missing_cases scrut_ty pats] returns [None] if [pats] cover all
+    possible values of [scrut_ty], or [Some descriptions] listing the
+    missing cases. Uses [type_ctor_env] to look up ADT constructors. *)
+let missing_cases (scrut_ty : ty) (pats : pattern list) : string list option =
+  let flat = List.concat_map flatten_or_pat pats in
+  if List.exists (fun p ->
+      match p.pat_desc with PWild | PVar _ -> true | _ -> false) flat
+  then None
+  else
+    match deref scrut_ty with
+    | TyCon "Bool" ->
+      let has_true  = List.exists (fun p -> p.pat_desc = PLitTrue)  flat in
+      let has_false = List.exists (fun p -> p.pat_desc = PLitFalse) flat in
+      let missing =
+        (if has_true  then [] else ["true"]) @
+        (if has_false then [] else ["false"])
+      in
+      if missing = [] then None else Some missing
+    | TyCon "Unit" ->
+      if List.exists (fun p -> p.pat_desc = PLitUnit) flat
+      then None else Some ["()"]
+    | TyCon "Int" | TyCon "String" | TyCon "Float64" ->
+      Some ["_ (wildcard required for infinite-domain types)"]
+    | TyCon type_name | TyApp (type_name, _) ->
+      (match List.assoc_opt type_name !type_ctor_env with
+       | None | Some [] -> None
+       | Some ctor_names ->
+         let missing = List.filter (fun ctor_name ->
+             not (List.exists (fun p ->
+                 match p.pat_desc with
+                 | PCtor (n, _) -> n = ctor_name
+                 | _ -> false) flat)
+           ) ctor_names in
+         if missing = [] then None else Some missing)
+    | TyRecord _ ->
+      if List.exists (fun p ->
+          match p.pat_desc with PRecord _ -> true | _ -> false) flat
+      then None else Some ["{...}"]
+    | _ -> None
+
+let check_match_exhaustive (scrut_ty : ty) (arms : match_arm list) =
+  let pats = List.map (fun arm -> arm.pattern) arms in
+  match missing_cases scrut_ty pats with
+  | None -> ()
+  | Some missing ->
+    let ty_str = match deref scrut_ty with
+      | TyCon n | TyApp (n, _) -> n
+      | t -> Format.asprintf "%a" pp_ty t
+    in
+    failwith (Printf.sprintf
+                "Typechecker: non-exhaustive match on type '%s'; \
+                 missing cases: %s"
+                ty_str (String.concat ", " missing))
+
+(* ------------------------------------------------------------------ *)
 (* Inference                                                            *)
 (* ------------------------------------------------------------------ *)
 
@@ -681,14 +749,14 @@ let rec infer_expr_in (eenv : effect_env) (env : env) (ambient : row) (e : expr)
     deref ret_ty
 
   | Match { scrutinee; arms } ->
-    let _scrut_ty = infer_expr_in eenv env ambient scrutinee in
+    let scrut_ty = infer_expr_in eenv env ambient scrutinee in
     let result_ty = fresh_meta () in
     List.iter (fun arm ->
-        (* Extend env with pattern bindings — conservative: only PVar binds *)
-        let env' = env_from_pattern env arm.pattern _scrut_ty in
+        let env' = env_from_pattern env arm.pattern scrut_ty in
         let arm_ty = infer_expr_in eenv env' ambient arm.arm_body in
         unify result_ty arm_ty
       ) arms;
+    check_match_exhaustive scrut_ty arms;
     deref result_ty
 
   | Record fields ->
@@ -1062,6 +1130,19 @@ let build_module_registry (prog : program) : module_registry =
     | _ -> None
   ) prog
 
+(** Build a map from each declared type name to the names of its constructors.
+    Used to populate [type_ctor_env] before exhaustiveness checking begins. *)
+let build_type_ctor_env (prog : program) : (string * string list) list =
+  let rec collect_decl acc d =
+    match d.decl_desc with
+    | DeclType { type_name; ctors; _ } ->
+      (type_name, List.map (fun c -> c.Ast.ctor_name) ctors) :: acc
+    | DeclModule { body; _ } ->
+      List.fold_left collect_decl acc body
+    | _ -> acc
+  in
+  List.fold_left collect_decl [] prog
+
 (** [check_program prog] type-checks a whole program in two passes:
 
     Pass 1 walks every declaration and builds:
@@ -1087,6 +1168,7 @@ let build_module_registry (prog : program) : module_registry =
     Returns the populated [(env, effect_env)] for reuse in tests and
     downstream tooling. Raises [Failure] on type errors. *)
 let check_program (prog : program) : env * effect_env =
+  type_ctor_env := build_type_ctor_env prog;
   let module_registry = build_module_registry prog in
   (* [add_qualified prefix mod_env mod_eenv env eenv] folds [mod_env] and
      [mod_eenv] into [env] and [eenv], prepending [prefix ^ "."] to each key. *)

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -541,8 +541,10 @@ let rec flatten_or_pat p =
 
 (** [missing_cases scrut_ty pats] returns [None] if [pats] cover all
     possible values of [scrut_ty], or [Some descriptions] listing the
-    missing cases. Uses [type_ctor_env] to look up ADT constructors. *)
-let missing_cases (scrut_ty : ty) (pats : pattern list) : string list option =
+    missing cases. Uses [type_ctor_env] to look up ADT constructors.
+    For record types, recursively checks that each field's sub-patterns
+    are themselves exhaustive for the field's type. *)
+let rec missing_cases (scrut_ty : ty) (pats : pattern list) : string list option =
   let flat = List.concat_map flatten_or_pat pats in
   if List.exists (fun p ->
       match p.pat_desc with PWild | PVar _ -> true | _ -> false) flat
@@ -573,10 +575,32 @@ let missing_cases (scrut_ty : ty) (pats : pattern list) : string list option =
                  | _ -> false) flat)
            ) ctor_names in
          if missing = [] then None else Some missing)
-    | TyRecord _ ->
-      if List.exists (fun p ->
-          match p.pat_desc with PRecord _ -> true | _ -> false) flat
-      then None else Some ["{...}"]
+    | TyRecord record_fields ->
+      let record_pats = List.filter_map (fun p ->
+          match p.pat_desc with
+          | PRecord (fps, is_open) -> Some (fps, is_open)
+          | _ -> None
+        ) flat in
+      if record_pats = [] then Some ["{...}"]
+      else
+        (* For each field, collect the sub-patterns from all record arms and
+           check that they recursively cover the field's type.  An open
+           pattern that omits a field implicitly covers it with a wildcard. *)
+        let missing_fields = List.filter_map (fun (field_name, field_ty) ->
+            let field_sub_pats = List.filter_map (fun (fps, is_open) ->
+                match List.assoc_opt field_name fps with
+                | Some sub_pat -> Some sub_pat
+                | None ->
+                  if is_open
+                  then Some { pat_desc = PWild; pat_comment = None }
+                  else None
+              ) record_pats in
+            match missing_cases field_ty field_sub_pats with
+            | None -> None
+            | Some _ -> Some field_name
+          ) record_fields in
+        if missing_fields = [] then None
+        else Some (List.map (fun f -> "field '" ^ f ^ "'") missing_fields)
     | _ -> None
 
 let check_match_exhaustive (scrut_ty : ty) (arms : match_arm list) =

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -1003,6 +1003,143 @@ let test_tyapp_result_arm_mismatch () =
     |}
 
 (* ------------------------------------------------------------------ *)
+(* Exhaustiveness checking                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* ADT: missing None arm is a type error. *)
+let test_exhaustive_adt_missing_ctor () =
+  check_program_error "non-exhaustive ADT match"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn bad(opt: Option<Int>) -> Int ! pure {
+        match opt with {
+          | Some(x) => x
+        }
+      }
+    |}
+
+(* ADT: all constructors covered, no error. *)
+let test_exhaustive_adt_full () =
+  check_program_ok "exhaustive ADT match"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn unwrap(opt: Option<Int>) -> Int ! pure {
+        match opt with {
+          | Some(x) => x
+          | None    => 0
+        }
+      }
+    |}
+
+(* Bool: missing false arm is a type error. *)
+let test_exhaustive_bool_missing_false () =
+  check_program_error "non-exhaustive Bool match (missing false)"
+    {|
+      fn bad(b: Bool) -> Int ! pure {
+        match b with {
+          | true => 1
+        }
+      }
+    |}
+
+(* Bool: missing true arm is a type error. *)
+let test_exhaustive_bool_missing_true () =
+  check_program_error "non-exhaustive Bool match (missing true)"
+    {|
+      fn bad(b: Bool) -> Int ! pure {
+        match b with {
+          | false => 0
+        }
+      }
+    |}
+
+(* Bool: both arms present, ok. *)
+let test_exhaustive_bool_full () =
+  check_program_ok "exhaustive Bool match"
+    {|
+      fn to_int(b: Bool) -> Int ! pure {
+        match b with {
+          | true  => 1
+          | false => 0
+        }
+      }
+    |}
+
+(* Int: literal-only match without wildcard is a type error. *)
+let test_exhaustive_int_no_wildcard () =
+  check_program_error "non-exhaustive Int match (no wildcard)"
+    {|
+      fn bad(n: Int) -> Int ! pure {
+        match n with {
+          | 0 => 0
+          | 1 => 1
+        }
+      }
+    |}
+
+(* String: literal-only match without wildcard is a type error. *)
+let test_exhaustive_string_no_wildcard () =
+  check_program_error "non-exhaustive String match (no wildcard)"
+    {|
+      fn bad(s: String) -> Int ! pure {
+        match s with {
+          | "a" => 0
+        }
+      }
+    |}
+
+(* Wildcard makes any match exhaustive. *)
+let test_exhaustive_wildcard_covers_all () =
+  check_program_ok "wildcard covers Int"
+    {|
+      fn describe(n: Int) -> Int ! pure {
+        match n with {
+          | 0 => 0
+          | _ => 1
+        }
+      }
+    |}
+
+(* Variable pattern makes any match exhaustive. *)
+let test_exhaustive_var_covers_all () =
+  check_program_ok "variable pattern covers ADT"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn to_zero(opt: Option<Int>) -> Int ! pure {
+        match opt with {
+          | x => 0
+        }
+      }
+    |}
+
+(* Or-pattern covering all Bool constructors is exhaustive. *)
+let test_exhaustive_or_pattern_bool () =
+  check_program_ok "or-pattern covers Bool"
+    {|
+      fn to_int(b: Bool) -> Int ! pure {
+        match b with {
+          | true | false => 0
+        }
+      }
+    |}
+
+(* Or-pattern covering all ADT constructors is exhaustive. *)
+let test_exhaustive_or_pattern_adt () =
+  check_program_ok "or-pattern covers Option"
+    {|
+      type Option<a> = | Some(a) | None
+
+      fn is_some(opt: Option<Int>) -> Int ! pure {
+        match opt with {
+          | Some(_) | None => 0
+        }
+      }
+    |}
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -1123,4 +1260,17 @@ let () =
         ; Alcotest.test_case "two-param Result"          `Quick test_tyapp_two_params
         ; Alcotest.test_case "Result match arms"         `Quick test_tyapp_result_match
         ; Alcotest.test_case "Result arm mismatch"       `Quick test_tyapp_result_arm_mismatch
+        ] )
+    ; ( "exhaustiveness",
+        [ Alcotest.test_case "ADT missing ctor"          `Quick test_exhaustive_adt_missing_ctor
+        ; Alcotest.test_case "ADT full coverage"         `Quick test_exhaustive_adt_full
+        ; Alcotest.test_case "Bool missing false"        `Quick test_exhaustive_bool_missing_false
+        ; Alcotest.test_case "Bool missing true"         `Quick test_exhaustive_bool_missing_true
+        ; Alcotest.test_case "Bool full coverage"        `Quick test_exhaustive_bool_full
+        ; Alcotest.test_case "Int no wildcard"           `Quick test_exhaustive_int_no_wildcard
+        ; Alcotest.test_case "String no wildcard"        `Quick test_exhaustive_string_no_wildcard
+        ; Alcotest.test_case "wildcard covers all"       `Quick test_exhaustive_wildcard_covers_all
+        ; Alcotest.test_case "var covers all"            `Quick test_exhaustive_var_covers_all
+        ; Alcotest.test_case "or-pattern Bool"           `Quick test_exhaustive_or_pattern_bool
+        ; Alcotest.test_case "or-pattern ADT"            `Quick test_exhaustive_or_pattern_adt
         ] ) ]

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -1139,6 +1139,55 @@ let test_exhaustive_or_pattern_adt () =
       }
     |}
 
+(* Record: wildcard/var sub-patterns make the match exhaustive. *)
+let test_exhaustive_record_wildcard_fields () =
+  check_program_ok "record with wildcard fields is exhaustive"
+    {|
+      fn get_x() -> Int ! pure {
+        let r = { x: 42, y: true } in
+        match r with {
+          | { x = n, y = _ } => n
+        }
+      }
+    |}
+
+(* Record: a literal sub-pattern does not cover the whole field domain. *)
+let test_exhaustive_record_literal_field () =
+  check_program_error "record with literal field is non-exhaustive"
+    {|
+      fn bad() -> Int ! pure {
+        let r = { x: 42 } in
+        match r with {
+          | { x = 0 } => 0
+        }
+      }
+    |}
+
+(* Record: two patterns together can cover the field domain. *)
+let test_exhaustive_record_multi_pattern () =
+  check_program_ok "two record patterns covering all field values"
+    {|
+      fn classify() -> Int ! pure {
+        let r = { x: 42 } in
+        match r with {
+          | { x = 0 } => 0
+          | { x = _ } => 1
+        }
+      }
+    |}
+
+(* Record: open pattern omitting a field implicitly wildcards that field. *)
+let test_exhaustive_record_open_pattern () =
+  check_program_ok "open record pattern covers omitted fields"
+    {|
+      fn get_x() -> Int ! pure {
+        let r = { x: 42, y: true } in
+        match r with {
+          | { x = n, .. } => n
+        }
+      }
+    |}
+
 (* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
@@ -1273,4 +1322,8 @@ let () =
         ; Alcotest.test_case "var covers all"            `Quick test_exhaustive_var_covers_all
         ; Alcotest.test_case "or-pattern Bool"           `Quick test_exhaustive_or_pattern_bool
         ; Alcotest.test_case "or-pattern ADT"            `Quick test_exhaustive_or_pattern_adt
+        ; Alcotest.test_case "record wildcard fields"    `Quick test_exhaustive_record_wildcard_fields
+        ; Alcotest.test_case "record literal field"      `Quick test_exhaustive_record_literal_field
+        ; Alcotest.test_case "record multi-pattern"      `Quick test_exhaustive_record_multi_pattern
+        ; Alcotest.test_case "record open pattern"       `Quick test_exhaustive_record_open_pattern
         ] ) ]


### PR DESCRIPTION
Implements exhaustiveness checking for `match` expressions (closes #18).

## Summary

- `missing_cases` in `typechecker.ml` computes which cases are absent for a given scrutinee type and set of patterns
- `check_match_exhaustive` is called at the end of `Match` inference and raises `Failure` with a message listing the missing cases
- `build_type_ctor_env` does a pre-pass over the program to map each declared type name to its constructor names; `check_program` populates the module-level `type_ctor_env` ref before inference begins

## Coverage rules

| Scrutinee type | Exhaustive when |
|---|---|
| `Bool` | both `true` and `false` arms present (or wildcard/var) |
| `Unit` | `()` arm present (or wildcard/var) |
| `Int` / `String` / `Float64` | wildcard or variable only (infinite domain) |
| ADT `TyCon t` / `TyApp (t, _)` | every constructor of `t` covered (or wildcard/var) |
| `TyRecord` | every field's sub-patterns recursively exhaustive for that field's type |
| Wildcard `_` / variable | always exhaustive |

Or-patterns (`p1 \| p2`) are flattened before the check so both branches contribute to coverage.

## Record exhaustiveness

Records are handled recursively rather than with the naïve "any record pattern covers it" shortcut. For a scrutinee of type `{f1: T1, f2: T2}`, the sub-patterns for each field are collected across all arms and checked against that field's type. An open pattern (`{ f = p, .. }`) that omits a field implicitly contributes a wildcard for that field.

## Tests

15 new test cases added to the `exhaustiveness` suite:
- Non-exhaustive ADT (missing constructor), full ADT coverage
- Bool missing `true`, Bool missing `false`, full Bool coverage
- `Int` / `String` without wildcard
- Wildcard covers infinite-domain types
- Variable pattern covers ADT
- Or-pattern covering `Bool`, or-pattern covering an ADT
- Record with wildcard fields (ok), record with literal field (error), two record patterns that together cover all values (ok), open record pattern omitting a field (ok)