### PR TITLE
Add support for open effect rows with row variable polymorphism

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -12,8 +12,8 @@ type type_expr =
                                             (** (T1, T2) -> T ! E *)
 
 and effect_set =
-  | Pure                        (** no effects *)
-  | Effects of type_expr list   (** { Log, Throw<E>, ... } *)
+  | Pure                                       (** no effects *)
+  | Effects of type_expr list * string option  (** { Log, Throw<E>, ... } or { Log | rho } *)
 
 (* ------------------------------------------------------------------ *)
 (* Function parameters                                                  *)
@@ -205,10 +205,15 @@ let rec pp_type_expr fmt = function
 
 and pp_effect_set fmt = function
   | Pure -> Format.pp_print_string fmt "pure"
-  | Effects ts ->
-    Format.fprintf fmt "{%a}"
+  | Effects (ts, tail) ->
+    let tail_str = match tail with
+      | None   -> ""
+      | Some v -> if ts = [] then "| " ^ v else " | " ^ v
+    in
+    Format.fprintf fmt "{%a%s}"
       (Format.pp_print_list ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
          pp_type_expr) ts
+      tail_str
 
 let pp_param fmt { param_name; param_type } =
   Format.fprintf fmt "%s: %a" param_name pp_type_expr param_type
@@ -358,11 +363,12 @@ let rec equal_type_expr a b = match a, b with
   | _,               _             -> false
 
 and equal_effect_set a b = match a, b with
-  | Pure,       Pure       -> true
-  | Effects xs, Effects ys ->
-    List.length xs = List.length ys
+  | Pure,                Pure                -> true
+  | Effects (xs, tx), Effects (ys, ty) ->
+    tx = ty
+    && List.length xs = List.length ys
     && List.for_all2 equal_type_expr xs ys
-  | _,          _          -> false
+  | _,                   _                   -> false
 
 let equal_param a b =
   a.param_name = b.param_name && equal_type_expr a.param_type b.param_type

--- a/lib/node_decoding.ml
+++ b/lib/node_decoding.ml
@@ -127,7 +127,8 @@ and get_effect_set cur =
   | t when t = etag_pure -> Pure
   | t when t = etag_effects ->
     let tys = get_list cur get_type_expr in
-    Effects tys
+    let tail = get_opt cur get_str in
+    Effects (tys, tail)
   | _ -> failwith (Printf.sprintf "Node_decoding: unknown effect_set tag 0x%02x" tag)
 
 let get_param cur =

--- a/lib/node_encoding.ml
+++ b/lib/node_encoding.ml
@@ -92,9 +92,10 @@ let rec put_type_expr buf = function
 and put_effect_set buf = function
   | Pure ->
     put_u8 buf etag_pure
-  | Effects tys ->
+  | Effects (tys, tail) ->
     put_u8 buf etag_effects;
-    put_list buf put_type_expr tys
+    put_list buf put_type_expr tys;
+    put_opt buf put_str tail
 
 let put_param buf (p : param) =
   put_str buf p.param_name;

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -114,12 +114,36 @@ and parse_effect_set (st : state) : effect_set =
   | Some LBrace ->
     advance st;
     (match peek st with
-     | Some RBrace -> advance st; Ast.Effects []
+     | Some RBrace -> advance st; Ast.Effects ([], None)
+     | Some Pipe ->
+       (* { | rho } — open row with no concrete effects, just a tail variable *)
+       advance st;
+       let v = match peek st with
+         | Some (Ident s) -> advance st; s
+         | Some t ->
+           failwith (Format.asprintf "Parser: expected row variable after '|', got %a" pp_token t)
+         | None -> failwith "Parser: expected row variable after '|'"
+       in
+       consume st RBrace;
+       Ast.Effects ([], Some v)
      | _ ->
        let first = parse_type_expr st in
        let rest  = parse_type_args_rest st in
+       let tail = match peek st with
+         | Some Pipe ->
+           advance st;
+           (match peek st with
+            | Some (Ident s) -> advance st; Some s
+            | Some t ->
+              failwith (Format.asprintf "Parser: expected row variable after '|', got %a" pp_token t)
+            | None -> failwith "Parser: expected row variable after '|'")
+         | _ -> None
+       in
        consume st RBrace;
-       Ast.Effects (first :: rest))
+       Ast.Effects (first :: rest, tail))
+  | Some (Ident s) ->
+    (* bare lowercase identifier as a row variable: ! e *)
+    advance st; Ast.Effects ([], Some s)
   | Some t ->
     failwith (Format.asprintf "Parser: expected effect set, got %a" pp_token t)
   | None -> failwith "Parser: expected effect set, got end of input"

--- a/lib/printer.ml
+++ b/lib/printer.ml
@@ -55,9 +55,13 @@ let rec print_type_expr = function
     "(" ^ String.concat ", " params_s ^ ") -> " ^ print_type_expr ret ^ eff_s
 
 and print_effect_set = function
-  | Pure       -> "pure"
-  | Effects [] -> "{}"
-  | Effects ts -> "{" ^ String.concat ", " (List.map print_type_expr ts) ^ "}"
+  | Pure -> "pure"
+  | Effects (ts, tail) ->
+    let tail_str = match tail with
+      | None   -> ""
+      | Some v -> if ts = [] then "| " ^ v else " | " ^ v
+    in
+    "{" ^ String.concat ", " (List.map print_type_expr ts) ^ tail_str ^ "}"
 
 let print_param { param_name; param_type } =
   param_name ^ ": " ^ print_type_expr param_type

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -478,57 +478,78 @@ let generalize env ty =
 (* Type-expression AST -> ty                                            *)
 (* ------------------------------------------------------------------ *)
 
-(** Convert an AST type_expr to a checker ty.
-    Type variables (lowercase names not in scope as type constructors)
-    are treated as rigid type variables. The innermost TyFun's row is
-    taken from the [effect_set option] on that arrow; intermediate
-    curried arrows default to a fresh open row.
+(** Maps named row-tail variables (e.g. the [e] in [{ Log | e }]) to a
+    shared [row_meta] within a single function signature so that two
+    occurrences of the same name produce the same unification variable. *)
+type row_var_env = (string, row_meta) Hashtbl.t
 
-    [None] effect slots — allowed by the parser for unannotated arrows
-    within type_expr — yield a fresh open row so type checking does not
-    prematurely constrain the function to pure. *)
-let rec ty_of_type_expr = function
+let new_row_var_env () : row_var_env = Hashtbl.create 4
+
+let find_or_create_row_meta (env : row_var_env) (name : string) : row_meta =
+  match Hashtbl.find_opt env name with
+  | Some rm -> rm
+  | None ->
+    let rm = fresh_row_meta () in
+    Hashtbl.add env name rm;
+    rm
+
+(** Convert an AST type_expr to a checker ty, sharing row-variable
+    metas within [env] so that the same variable name at two positions
+    maps to the same [RMeta]. *)
+let rec ty_of_type_expr_env (env : row_var_env) = function
   | TyName s when String.length s > 0 && s.[0] >= 'a' && s.[0] <= 'z' ->
     TyVar s
   | TyName s  -> TyCon s
-  | TyApp (s, args) -> TyApp (s, List.map ty_of_type_expr args)
+  | TyApp (s, args) -> TyApp (s, List.map (ty_of_type_expr_env env) args)
   | TyTuple _ -> fresh_meta ()    (* tuple types deferred *)
   | TyFun (param_tys, ret, eff) ->
-    let ret_ty = ty_of_type_expr ret in
-    let row = row_of_effect_set_opt eff in
+    let ret_ty = ty_of_type_expr_env env ret in
+    let row = row_of_effect_set_opt_env env eff in
     (* Curried: the declared effect row lives on the innermost arrow (the
        last one to be applied), so we build from the right and attach [row]
        there. Intermediate arrows get fresh open rows. *)
     (match List.rev param_tys with
      | [] -> ret_ty   (* nullary function types have no arrow at all *)
      | last :: rest_rev ->
-       let innermost = TyFun (ty_of_type_expr last, ret_ty, row) in
+       let innermost = TyFun (ty_of_type_expr_env env last, ret_ty, row) in
        List.fold_left
-         (fun acc pt -> TyFun (ty_of_type_expr pt, acc, fresh_row ()))
+         (fun acc pt -> TyFun (ty_of_type_expr_env env pt, acc, fresh_row ()))
          innermost rest_rev)
 
-(** Convert an AST [effect_set] to a checker row. [Effects [e1; ...; en]]
-    becomes [RCons (e1, ... RCons (en, RPure))] (closed); [Pure] is
-    [RPure]. *)
-and row_of_effect_set = function
+(** Convert an AST [effect_set] to a checker row using [env] to share
+    row-variable metas. [Pure] → [RPure]; closed [Effects] → [RCons]
+    chain ending in [RPure]; open [Effects] with tail variable → chain
+    ending in the [RMeta] for that variable. *)
+and row_of_effect_set_env (env : row_var_env) = function
   | Pure -> RPure
-  | Effects ts ->
+  | Effects (ts, None) ->
     List.fold_right
-      (fun t acc -> RCons (effect_inst_of_type_expr t, acc))
+      (fun t acc -> RCons (effect_inst_of_type_expr_env env t, acc))
       ts RPure
+  | Effects (ts, Some v) ->
+    let rm = find_or_create_row_meta env v in
+    List.fold_right
+      (fun t acc -> RCons (effect_inst_of_type_expr_env env t, acc))
+      ts (RMeta rm)
 
-and row_of_effect_set_opt = function
-  | Some e -> row_of_effect_set e
+and row_of_effect_set_opt_env (env : row_var_env) = function
+  | Some e -> row_of_effect_set_env env e
   | None   -> fresh_row ()   (* unannotated: inference will discover it *)
 
-and effect_inst_of_type_expr = function
+and effect_inst_of_type_expr_env (env : row_var_env) = function
   | TyName s -> { eff_name = s; eff_args = [] }
   | TyApp (s, args) ->
-    { eff_name = s; eff_args = List.map ty_of_type_expr args }
+    { eff_name = s; eff_args = List.map (ty_of_type_expr_env env) args }
   | t ->
     failwith (Format.asprintf
                 "Typechecker: not a legal effect: %a"
                 Ast.pp_type_expr t)
+
+(** Shims with the original names — use a fresh empty env so existing
+    call sites that don't need row-variable sharing continue to work. *)
+let ty_of_type_expr t       = ty_of_type_expr_env (new_row_var_env ()) t
+let row_of_effect_set e     = row_of_effect_set_env (new_row_var_env ()) e
+let row_of_effect_set_opt e = row_of_effect_set_opt_env (new_row_var_env ()) e
 
 (* ------------------------------------------------------------------ *)
 (* Exhaustiveness checking                                              *)
@@ -1153,19 +1174,22 @@ let effect_scheme_of_decl (type_params : string list) (ops : Ast.effect_op list)
 
 (** Build a top-level function scheme from its declared parameter types
     and return type. Type parameters named on the declaration become the
-    scheme's bound variables so callers instantiate them with fresh metas. *)
+    scheme's bound variables so callers instantiate them with fresh metas.
+    A shared [row_var_env] ensures that the same row-variable name at
+    different positions in the signature maps to the same [RMeta]. *)
 let fn_scheme_of_decl
     (type_params : string list)
     (params      : param list)
     (return_type : type_expr option)
     (effects     : effect_set option)
   : scheme =
-  let param_tys = List.map (fun p -> ty_of_type_expr p.param_type) params in
+  let renv = new_row_var_env () in
+  let param_tys = List.map (fun p -> ty_of_type_expr_env renv p.param_type) params in
   let ret_ty = match return_type with
-    | Some t -> ty_of_type_expr t
+    | Some t -> ty_of_type_expr_env renv t
     | None   -> fresh_meta ()
   in
-  let body_row = row_of_effect_set_opt effects in
+  let body_row = row_of_effect_set_opt_env renv effects in
   let fun_ty = match List.rev param_tys with
     | [] -> ret_ty
     | last :: rest_rev ->
@@ -1326,7 +1350,11 @@ let check_program (prog : program) : env * effect_env =
   let rec check_decl d =
     match d.decl_desc with
     | DeclFn { params; return_type; effects; decl_body; _ } ->
-      let param_tys = List.map (fun p -> ty_of_type_expr p.param_type) params in
+      (* Use a shared row-var env so that the same row-variable name in the
+         param types, effect annotation, and return type produces the same
+         RMeta, giving the body check consistent ambient rows. *)
+      let renv = new_row_var_env () in
+      let param_tys = List.map (fun p -> ty_of_type_expr_env renv p.param_type) params in
       let body_env =
         List.fold_left2 (fun acc p t -> env_extend p.param_name (mono t) acc)
           env0 params param_tys
@@ -1334,10 +1362,10 @@ let check_program (prog : program) : env * effect_env =
       (* The body runs in the ambient row declared on the signature. If
          the signature omits the effect annotation, use a fresh open row
          so inference can discover the effects performed. *)
-      let ambient = row_of_effect_set_opt effects in
+      let ambient = row_of_effect_set_opt_env renv effects in
       let body_ty = infer_expr_in eenv0 body_env ambient decl_body in
       (match return_type with
-       | Some t -> unify body_ty (ty_of_type_expr t)
+       | Some t -> unify body_ty (ty_of_type_expr_env renv t)
        | None   -> ())
     | DeclModule { body; _ } ->
       List.iter check_decl body

--- a/test/test_decl_parser.ml
+++ b/test/test_decl_parser.ml
@@ -203,6 +203,58 @@ let test_program_two_fns () =
                 ; return_type = None; effects = None; decl_body = expr (Var "y") }) ]
 
 (* ------------------------------------------------------------------ *)
+(* Open effect rows — { E | rho } syntax                               *)
+(* ------------------------------------------------------------------ *)
+
+(* fn f(x: Int) -> Int ! {Log | e} { x }  — effect with tail variable *)
+let test_open_effect_row () =
+  check_decl "open effect row"
+    "fn f(x: Int) -> Int ! {Log | e} { x }"
+    (decl (DeclFn { pub         = false
+               ; fn_name     = "f"
+               ; type_params = []
+               ; params      = [{ param_name = "x"; param_type = TyName "Int" }]
+               ; return_type = Some (TyName "Int")
+               ; effects     = Some (Effects ([TyName "Log"], Some "e"))
+               ; decl_body   = expr (Var "x") }))
+
+(* fn f() -> Unit ! { | e} { () }  — just a tail variable, no concrete effects *)
+let test_open_effect_row_tail_only () =
+  check_decl "open effect row tail only"
+    "fn f() -> Unit ! {| e} { () }"
+    (decl (DeclFn { pub         = false
+               ; fn_name     = "f"
+               ; type_params = []
+               ; params      = []
+               ; return_type = Some (TyName "Unit")
+               ; effects     = Some (Effects ([], Some "e"))
+               ; decl_body   = expr UnitLit }))
+
+(* fn f() -> Unit ! e { () }  — bare row variable *)
+let test_bare_row_variable () =
+  check_decl "bare row variable"
+    "fn f() -> Unit ! e { () }"
+    (decl (DeclFn { pub         = false
+               ; fn_name     = "f"
+               ; type_params = []
+               ; params      = []
+               ; return_type = Some (TyName "Unit")
+               ; effects     = Some (Effects ([], Some "e"))
+               ; decl_body   = expr UnitLit }))
+
+(* fn f() -> Unit ! {Log, Console | e} { () }  — multiple effects with tail *)
+let test_open_effect_row_multi () =
+  check_decl "open effect row multiple effects"
+    "fn f() -> Unit ! {Log, Console | e} { () }"
+    (decl (DeclFn { pub         = false
+               ; fn_name     = "f"
+               ; type_params = []
+               ; params      = []
+               ; return_type = Some (TyName "Unit")
+               ; effects     = Some (Effects ([TyName "Log"; TyName "Console"], Some "e"))
+               ; decl_body   = expr UnitLit }))
+
+(* ------------------------------------------------------------------ *)
 (* Comment attachment on declarations                                   *)
 (* ------------------------------------------------------------------ *)
 
@@ -261,4 +313,10 @@ let () =
     ; ( "comments",
         [ Alcotest.test_case "fn comment"      `Quick test_fn_decl_comment
         ; Alcotest.test_case "type comment"    `Quick test_type_decl_comment
+        ] )
+    ; ( "open-effect-rows",
+        [ Alcotest.test_case "effect with tail var"      `Quick test_open_effect_row
+        ; Alcotest.test_case "tail variable only"        `Quick test_open_effect_row_tail_only
+        ; Alcotest.test_case "bare row variable"         `Quick test_bare_row_variable
+        ; Alcotest.test_case "multiple effects with tail" `Quick test_open_effect_row_multi
         ] ) ]

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -152,7 +152,7 @@ let test_fn_effect_set () =
     "fn (x: Int) -> Int ! {Log} { x }"
     (expr (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
            ; return_type = Some (TyName "Int")
-           ; effects     = Some (Effects [TyName "Log"])
+           ; effects     = Some (Effects ([TyName "Log"], None))
            ; fn_body     = expr (Var "x") }))
 
 (* ------------------------------------------------------------------ *)

--- a/test/test_printer.ml
+++ b/test/test_printer.ml
@@ -115,7 +115,7 @@ let test_fn_effect_set () =
   rt_expr "fn effect set"
     (expr (Fn { params      = [{ param_name = "x"; param_type = TyName "Int" }]
                ; return_type = Some (TyName "Int")
-               ; effects     = Some (Effects [TyName "Log"])
+               ; effects     = Some (Effects ([TyName "Log"], None))
                ; fn_body     = expr (Var "x") }))
 
 let test_fn_generic_param () =
@@ -413,7 +413,7 @@ let test_ty_fun_effects () =
   rt_expr "type fun with effects"
     (fn_with_ty
        (TyFun ([TyName "Int"], TyName "Int",
-               Some (Effects [TyName "Log"; TyName "State"]))))
+               Some (Effects ([TyName "Log"; TyName "State"], None)))))
 
 (* ------------------------------------------------------------------ *)
 (* Comments                                                             *)

--- a/test/test_roundtrip.ml
+++ b/test/test_roundtrip.ml
@@ -186,7 +186,7 @@ let test_fn_effect_set () =
   check_expr "Fn effect set"
     (expr (Fn { params = [{ param_name = "x"; param_type = TyName "Int" }]
               ; return_type = Some (TyName "Unit")
-              ; effects = Some (Effects [TyName "Log"; TyApp ("Throw", [TyName "E"])])
+              ; effects = Some (Effects ([TyName "Log"; TyApp ("Throw", [TyName "E"])], None))
               ; fn_body = expr UnitLit }))
 
 let test_fn_complex_types () =

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -1327,6 +1327,70 @@ let test_stdlib_example_02_list () =
       }
     |}
 
+(* ------------------------------------------------------------------ *)
+(* Open effect rows — row variable polymorphism                        *)
+(* ------------------------------------------------------------------ *)
+
+(* A function declared with a row variable in its effect set type-checks. *)
+let test_row_var_open_row_parses () =
+  check_program_ok "open effect row parses and type-checks"
+    {|
+      effect Log {
+        log: (String) -> Unit
+      }
+
+      fn wrap(body: (u: Unit) -> Unit ! {Log | e}) -> Unit ! {Log | e} {
+        body(())
+      }
+    |}
+
+(* Two occurrences of the same row variable in a function signature share
+   the same RMeta, allowing the two positions to be used consistently.
+   Here both parameters and the return effect use the same variable [e]. *)
+let test_row_var_same_var_unifies () =
+  check_program_ok "same row variable in two positions unifies"
+    {|
+      fn either_eff(f: (u: Unit) -> Unit ! e, g: (u: Unit) -> Unit ! e) -> Unit ! e {
+        f(())
+      }
+    |}
+
+(* A function with a bare row variable effect can be called from a pure context. *)
+let test_row_var_callable_pure () =
+  check_program_ok "row-variable function callable from pure context"
+    {|
+      fn call_it(f: (u: Unit) -> Unit ! e) -> Unit ! e {
+        f(())
+      }
+
+      fn pure_body(u: Unit) -> Unit ! pure { () }
+
+      fn use_pure() -> Unit ! pure {
+        call_it(pure_body)
+      }
+    |}
+
+(* A function with a bare row variable effect can be called from an effectful context. *)
+let test_row_var_callable_effectful () =
+  check_program_ok "row-variable function callable from effectful context"
+    {|
+      effect Log {
+        log: (String) -> Unit
+      }
+
+      fn call_it(f: (u: Unit) -> Unit ! e) -> Unit ! e {
+        f(())
+      }
+
+      fn log_body(u: Unit) -> Unit ! {Log} {
+        perform Log.log("hi")
+      }
+
+      fn use_effectful() -> Unit ! {Log} {
+        call_it(log_body)
+      }
+    |}
+
 (* examples/02_data_types.axm Result helpers type-check with the stdlib. *)
 let test_stdlib_example_02_result () =
   check_program_ok "02_data_types Result functions"
@@ -1479,6 +1543,12 @@ let () =
         ; Alcotest.test_case "record literal field"      `Quick test_exhaustive_record_literal_field
         ; Alcotest.test_case "record multi-pattern"      `Quick test_exhaustive_record_multi_pattern
         ; Alcotest.test_case "record open pattern"       `Quick test_exhaustive_record_open_pattern
+        ] )
+    ; ( "open-effect-rows",
+        [ Alcotest.test_case "open row parses"           `Quick test_row_var_open_row_parses
+        ; Alcotest.test_case "same var unifies"          `Quick test_row_var_same_var_unifies
+        ; Alcotest.test_case "callable from pure"        `Quick test_row_var_callable_pure
+        ; Alcotest.test_case "callable from effectful"   `Quick test_row_var_callable_effectful
         ] )
     ; ( "stdlib",
         [ Alcotest.test_case "add"                       `Quick test_stdlib_add


### PR DESCRIPTION
## Summary
This PR adds support for open effect rows in function signatures, allowing functions to be polymorphic over their effect sets using row variables. Functions can now declare effects like `{Log | e}` or bare `e`, where the row variable can be instantiated with different effect sets at call sites.

## Key Changes

- **AST Enhancement**: Modified `effect_set` type to support an optional tail variable: `Effects of type_expr list * string option` instead of just `Effects of type_expr list`. This allows syntax like `{Log, Console | e}` or `{| e}` or bare `e`.

- **Parser Updates**: Extended `parse_effect_set` to handle:
  - Open rows with concrete effects and a tail: `{Log | e}`
  - Open rows with only a tail: `{| e}`
  - Bare row variables: `e` (parsed as `Effects ([], Some "e")`)

- **Type Checker Row Variable Sharing**: Introduced `row_var_env` (a hashtable mapping row variable names to `row_meta`) to ensure that the same row variable name appearing in multiple positions within a function signature (parameter types, return type, effect annotation) maps to the same unification variable. This is critical for type consistency.

- **Refactored Type Conversion Functions**: 
  - Renamed core functions to `*_env` variants that accept and thread through `row_var_env`
  - Created shim functions with original names that use a fresh empty environment for backward compatibility
  - Updated `fn_scheme_of_decl` and `check_decl` to create and share a single `row_var_env` across all type conversions in a signature

- **Test Coverage**: Added comprehensive tests for:
  - Parsing open effect rows with various syntaxes
  - Type checking functions with row variables in multiple positions
  - Calling row-variable functions from both pure and effectful contexts

## Implementation Details

The key insight is that row variables must be shared within a single function signature. When converting a function's parameter types, return type, and effect annotation, all conversions use the same `row_var_env`. This ensures that if `e` appears in both a parameter type and the effect annotation, they refer to the same `RMeta`, allowing the type checker to properly unify and constrain the row variable based on actual usage.

The parser now treats bare lowercase identifiers in effect position as row variables rather than effect names, enabling the `! e` syntax.

https://claude.ai/code/session_01QXU1kvsCQfTfndSe4UK2t1