### PR TITLE
Add WASM binary encoder for Milestone 1 codegen

### DIFF
--- a/lib/wasm/dune
+++ b/lib/wasm/dune
@@ -1,0 +1,3 @@
+(library
+ (name wasm_encode)
+ (modules wasm_encode))

--- a/lib/wasm/wasm_encode.ml
+++ b/lib/wasm/wasm_encode.ml
@@ -1,0 +1,462 @@
+(** WASM binary encoder for Milestone 1 codegen.
+
+    Covers: LEB128 helpers, section emitters, a structured instruction type
+    for the required opcode subset, function-body encoding, and a module
+    builder with add_type / add_func / add_export helpers.
+
+    Out of scope: Memory64, GC proposal, exception-handling, full instruction
+    set.  Add encodings on demand in later sub-issues. *)
+
+(* ------------------------------------------------------------------ *)
+(* Types                                                               *)
+(* ------------------------------------------------------------------ *)
+
+type val_type = I32 | I64 | F32 | F64
+
+(** Block type annotation for if/block/loop. *)
+type block_type =
+  | Void             (** No result (0x40) *)
+  | ValType of val_type
+  | TypeIdx of int   (** Multi-value: signed LEB128 index into type section *)
+
+(** Instruction subset required for Milestone 1. *)
+type instr =
+  | I32Const of int
+  | I32Add
+  | I32Sub
+  | I32Mul
+  | I32Eq
+  | I32LtS
+  | I32GtS
+  | LocalGet of int
+  | LocalSet of int
+  | LocalTee of int
+  | Call of int
+  | If of block_type * instr list * instr list option
+  | Block of block_type * instr list
+  | Loop of block_type * instr list
+  | Br of int
+  | BrIf of int
+  | BrTable of int list * int  (** targets, default *)
+  | Return
+  | Drop
+
+(** Run-length encoded local variable group in a function body. *)
+type local_decl = {
+  count : int;
+  ty : val_type;
+}
+
+(** A function's type signature. *)
+type func_type = {
+  params : val_type list;
+  results : val_type list;
+}
+
+(** Export descriptor. *)
+type export_desc =
+  | ExportFunc of int
+  | ExportTable of int
+  | ExportMem of int
+  | ExportGlobal of int
+
+(** Import descriptor (func imports only for now). *)
+type import_desc =
+  | ImportFunc of int  (** type index *)
+
+(** Constant initialiser for globals. *)
+type global_init =
+  | GlobI32 of int
+  | GlobI64 of int64
+  | GlobF32 of float
+  | GlobF64 of float
+
+(** Memory / table size constraints. *)
+type limits = {
+  min : int;
+  max : int option;
+}
+
+(** Active data segment targeting memory 0. *)
+type data_segment = {
+  offset : int;
+  data : bytes;
+}
+
+(** Active element segment targeting table 0. *)
+type elem_segment = {
+  elem_offset : int;
+  func_indices : int list;
+}
+
+(** Mutable accumulator used to build a WASM module incrementally. *)
+type module_builder = {
+  mutable types    : func_type list;
+  mutable imports  : (string * string * import_desc) list;
+  mutable funcs    : int list;
+  mutable tables   : limits list;
+  mutable memories : limits list;
+  mutable globals  : (val_type * bool * global_init) list;
+  mutable exports  : (string * export_desc) list;
+  mutable start    : int option;
+  mutable elements : elem_segment list;
+  mutable bodies   : (local_decl list * instr list) list;
+  mutable data     : data_segment list;
+}
+
+(* ------------------------------------------------------------------ *)
+(* Low-level byte-emission primitives                                  *)
+(* ------------------------------------------------------------------ *)
+
+let put_byte buf b =
+  Buffer.add_char buf (Char.chr (b land 0xFF))
+
+let put_u32_le buf n =
+  put_byte buf (n land 0xFF);
+  put_byte buf ((n lsr 8)  land 0xFF);
+  put_byte buf ((n lsr 16) land 0xFF);
+  put_byte buf ((n lsr 24) land 0xFF)
+
+(** Unsigned LEB128 (used for counts, section sizes, unsigned indices). *)
+let put_uleb128 buf n =
+  let n = ref n in
+  let go = ref true in
+  while !go do
+    let byte = !n land 0x7F in
+    n := !n lsr 7;
+    if !n = 0 then (put_byte buf byte; go := false)
+    else put_byte buf (byte lor 0x80)
+  done
+
+(** Signed LEB128 (used for i32.const immediates and block type indices). *)
+let put_sleb128 buf n =
+  let n = ref n in
+  let go = ref true in
+  while !go do
+    let byte = !n land 0x7F in
+    n := !n asr 7;
+    if (!n = 0 && byte land 0x40 = 0) || (!n = -1 && byte land 0x40 <> 0)
+    then (put_byte buf byte; go := false)
+    else put_byte buf (byte lor 0x80)
+  done
+
+(** Length-prefixed UTF-8 string (uleb128 length then raw bytes). *)
+let put_string buf s =
+  put_uleb128 buf (String.length s);
+  Buffer.add_string buf s
+
+(* ------------------------------------------------------------------ *)
+(* Value / block type encoding                                         *)
+(* ------------------------------------------------------------------ *)
+
+let byte_of_val_type = function
+  | I32 -> 0x7F
+  | I64 -> 0x7E
+  | F32 -> 0x7D
+  | F64 -> 0x7C
+
+let put_val_type buf vt = put_byte buf (byte_of_val_type vt)
+
+let put_block_type buf = function
+  | Void       -> put_byte buf 0x40
+  | ValType vt -> put_val_type buf vt
+  | TypeIdx i  -> put_sleb128 buf i
+
+(* ------------------------------------------------------------------ *)
+(* Instruction encoding                                                *)
+(* ------------------------------------------------------------------ *)
+
+let rec put_instr buf instr =
+  match instr with
+  | I32Const n ->
+    put_byte buf 0x41;
+    put_sleb128 buf n
+  | I32Add  -> put_byte buf 0x6A
+  | I32Sub  -> put_byte buf 0x6B
+  | I32Mul  -> put_byte buf 0x6C
+  | I32Eq   -> put_byte buf 0x46
+  | I32LtS  -> put_byte buf 0x48
+  | I32GtS  -> put_byte buf 0x4A
+  | LocalGet i ->
+    put_byte buf 0x20;
+    put_uleb128 buf i
+  | LocalSet i ->
+    put_byte buf 0x21;
+    put_uleb128 buf i
+  | LocalTee i ->
+    put_byte buf 0x22;
+    put_uleb128 buf i
+  | Call i ->
+    put_byte buf 0x10;
+    put_uleb128 buf i
+  | If (bt, then_b, else_opt) ->
+    put_byte buf 0x04;
+    put_block_type buf bt;
+    List.iter (put_instr buf) then_b;
+    (match else_opt with
+     | Some else_b ->
+       put_byte buf 0x05;
+       List.iter (put_instr buf) else_b
+     | None -> ());
+    put_byte buf 0x0B
+  | Block (bt, body) ->
+    put_byte buf 0x02;
+    put_block_type buf bt;
+    List.iter (put_instr buf) body;
+    put_byte buf 0x0B
+  | Loop (bt, body) ->
+    put_byte buf 0x03;
+    put_block_type buf bt;
+    List.iter (put_instr buf) body;
+    put_byte buf 0x0B
+  | Br label ->
+    put_byte buf 0x0C;
+    put_uleb128 buf label
+  | BrIf label ->
+    put_byte buf 0x0D;
+    put_uleb128 buf label
+  | BrTable (targets, default) ->
+    put_byte buf 0x0E;
+    put_uleb128 buf (List.length targets);
+    List.iter (put_uleb128 buf) targets;
+    put_uleb128 buf default
+  | Return -> put_byte buf 0x0F
+  | Drop   -> put_byte buf 0x1A
+
+(* ------------------------------------------------------------------ *)
+(* Section helpers                                                     *)
+(* ------------------------------------------------------------------ *)
+
+(** Write a section: emit the id byte, compute content into a temp buffer,
+    then emit the uleb128 size followed by the content bytes. *)
+let emit_section buf id encode_content data =
+  put_byte buf id;
+  let sec = Buffer.create 32 in
+  encode_content sec data;
+  let sec_bytes = Buffer.to_bytes sec in
+  put_uleb128 buf (Bytes.length sec_bytes);
+  Buffer.add_bytes buf sec_bytes
+
+(* ------------------------------------------------------------------ *)
+(* Per-section encoders                                                *)
+(* ------------------------------------------------------------------ *)
+
+let encode_type_section buf types =
+  put_uleb128 buf (List.length types);
+  List.iter (fun { params; results } ->
+    put_byte buf 0x60;
+    put_uleb128 buf (List.length params);
+    List.iter (put_val_type buf) params;
+    put_uleb128 buf (List.length results);
+    List.iter (put_val_type buf) results
+  ) types
+
+let encode_import_section buf imports =
+  put_uleb128 buf (List.length imports);
+  List.iter (fun (modname, fieldname, desc) ->
+    put_string buf modname;
+    put_string buf fieldname;
+    match desc with
+    | ImportFunc type_idx ->
+      put_byte buf 0x00;
+      put_uleb128 buf type_idx
+  ) imports
+
+let encode_func_section buf funcs =
+  put_uleb128 buf (List.length funcs);
+  List.iter (put_uleb128 buf) funcs
+
+let put_limits buf { min; max } =
+  match max with
+  | None   -> put_byte buf 0x00; put_uleb128 buf min
+  | Some n -> put_byte buf 0x01; put_uleb128 buf min; put_uleb128 buf n
+
+let encode_table_section buf tables =
+  put_uleb128 buf (List.length tables);
+  List.iter (fun lim ->
+    put_byte buf 0x70;   (* funcref *)
+    put_limits buf lim
+  ) tables
+
+let encode_memory_section buf memories =
+  put_uleb128 buf (List.length memories);
+  List.iter (put_limits buf) memories
+
+let put_global_init buf = function
+  | GlobI32 n ->
+    put_byte buf 0x41; put_sleb128 buf n; put_byte buf 0x0B
+  | GlobI64 n ->
+    put_byte buf 0x42;
+    let n = ref n in
+    let go = ref true in
+    while !go do
+      let byte = Int64.to_int (Int64.logand !n 0x7FL) in
+      n := Int64.shift_right !n 7;
+      if (!n = 0L && byte land 0x40 = 0) || (!n = Int64.minus_one && byte land 0x40 <> 0)
+      then (put_byte buf byte; go := false)
+      else put_byte buf (byte lor 0x80)
+    done;
+    put_byte buf 0x0B
+  | GlobF32 f ->
+    put_byte buf 0x43;
+    let bits = Int32.bits_of_float f in
+    for i = 0 to 3 do
+      put_byte buf (Int32.to_int (Int32.logand (Int32.shift_right_logical bits (i * 8)) 0xFFl))
+    done;
+    put_byte buf 0x0B
+  | GlobF64 f ->
+    put_byte buf 0x44;
+    let bits = Int64.bits_of_float f in
+    for i = 0 to 7 do
+      put_byte buf (Int64.to_int (Int64.logand (Int64.shift_right_logical bits (i * 8)) 0xFFL))
+    done;
+    put_byte buf 0x0B
+
+let encode_global_section buf globals =
+  put_uleb128 buf (List.length globals);
+  List.iter (fun (vt, mut_, init) ->
+    put_val_type buf vt;
+    put_byte buf (if mut_ then 1 else 0);
+    put_global_init buf init
+  ) globals
+
+let encode_export_section buf exports =
+  put_uleb128 buf (List.length exports);
+  List.iter (fun (name, desc) ->
+    put_string buf name;
+    match desc with
+    | ExportFunc  i -> put_byte buf 0x00; put_uleb128 buf i
+    | ExportTable i -> put_byte buf 0x01; put_uleb128 buf i
+    | ExportMem   i -> put_byte buf 0x02; put_uleb128 buf i
+    | ExportGlobal i -> put_byte buf 0x03; put_uleb128 buf i
+  ) exports
+
+let encode_code_section buf bodies =
+  put_uleb128 buf (List.length bodies);
+  List.iter (fun (locals, instrs) ->
+    let body = Buffer.create 32 in
+    put_uleb128 body (List.length locals);
+    List.iter (fun { count; ty } ->
+      put_uleb128 body count;
+      put_val_type body ty
+    ) locals;
+    List.iter (put_instr body) instrs;
+    put_byte body 0x0B;   (* end of function body *)
+    let body_bytes = Buffer.to_bytes body in
+    put_uleb128 buf (Bytes.length body_bytes);
+    Buffer.add_bytes buf body_bytes
+  ) bodies
+
+let encode_element_section buf elements =
+  put_uleb128 buf (List.length elements);
+  List.iter (fun { elem_offset; func_indices } ->
+    put_byte buf 0x00;         (* kind 0: active, table 0, funcref *)
+    put_byte buf 0x41; put_sleb128 buf elem_offset; put_byte buf 0x0B;
+    put_uleb128 buf (List.length func_indices);
+    List.iter (put_uleb128 buf) func_indices
+  ) elements
+
+let encode_data_section buf data =
+  put_uleb128 buf (List.length data);
+  List.iter (fun { offset; data = d } ->
+    put_byte buf 0x00;         (* active, memory 0 *)
+    put_byte buf 0x41; put_sleb128 buf offset; put_byte buf 0x0B;
+    put_uleb128 buf (Bytes.length d);
+    Buffer.add_bytes buf d
+  ) data
+
+(* ------------------------------------------------------------------ *)
+(* Full module encoding                                                *)
+(* ------------------------------------------------------------------ *)
+
+let encode m =
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf "\x00asm";
+  put_u32_le buf 1;
+  if m.types    <> [] then emit_section buf  1 encode_type_section    m.types;
+  if m.imports  <> [] then emit_section buf  2 encode_import_section  m.imports;
+  if m.funcs    <> [] then emit_section buf  3 encode_func_section    m.funcs;
+  if m.tables   <> [] then emit_section buf  4 encode_table_section   m.tables;
+  if m.memories <> [] then emit_section buf  5 encode_memory_section  m.memories;
+  if m.globals  <> [] then emit_section buf  6 encode_global_section  m.globals;
+  if m.exports  <> [] then emit_section buf  7 encode_export_section  m.exports;
+  (match m.start with
+   | Some idx ->
+     let sec = Buffer.create 4 in
+     put_uleb128 sec idx;
+     let sec_bytes = Buffer.to_bytes sec in
+     put_byte buf 8;
+     put_uleb128 buf (Bytes.length sec_bytes);
+     Buffer.add_bytes buf sec_bytes
+   | None -> ());
+  if m.elements <> [] then emit_section buf  9 encode_element_section m.elements;
+  if m.bodies   <> [] then emit_section buf 10 encode_code_section    m.bodies;
+  if m.data     <> [] then emit_section buf 11 encode_data_section    m.data;
+  Buffer.to_bytes buf
+
+(* ------------------------------------------------------------------ *)
+(* Module builder API                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let create () = {
+  types = []; imports = []; funcs = []; tables = []; memories = [];
+  globals = []; exports = []; start = None; elements = []; bodies = [];
+  data = [];
+}
+
+(** Add a function type; returns its index in the type section. *)
+let add_type m ft =
+  let idx = List.length m.types in
+  m.types <- m.types @ [ft];
+  idx
+
+(** Add an import; does not affect the local function index space directly
+    but the import count is included when computing function indices. *)
+let add_import m modname fieldname desc =
+  m.imports <- m.imports @ [(modname, fieldname, desc)]
+
+(** Add a local function (type index + body); returns the function index
+    (import count + position in local function list). *)
+let add_func m type_idx locals instrs =
+  let func_idx = List.length m.imports + List.length m.funcs in
+  m.funcs  <- m.funcs  @ [type_idx];
+  m.bodies <- m.bodies @ [(locals, instrs)];
+  func_idx
+
+(** Add a table with the given limits. *)
+let add_table m lim =
+  m.tables <- m.tables @ [lim]
+
+(** Add a memory with the given limits. *)
+let add_memory m lim =
+  m.memories <- m.memories @ [lim]
+
+(** Add a global (val_type, mutable, init expression). *)
+let add_global m vt mut_ init =
+  let idx = List.length m.globals in
+  m.globals <- m.globals @ [(vt, mut_, init)];
+  idx
+
+(** Add a named export. *)
+let add_export m name desc =
+  m.exports <- m.exports @ [(name, desc)]
+
+(** Set the start function (called on module instantiation). *)
+let set_start m idx =
+  m.start <- Some idx
+
+(** Add an active element segment for table 0. *)
+let add_element m elem_offset func_indices =
+  m.elements <- m.elements @ [{ elem_offset; func_indices }]
+
+(** Add an active data segment for memory 0. *)
+let add_data m offset data =
+  m.data <- m.data @ [{ offset; data }]
+
+(** Convenience: define a complete function (type + body) with an export
+    name; returns the function index. *)
+let add_function m ?(export = "") params results locals instrs =
+  let type_idx = add_type m { params; results } in
+  let func_idx = add_func m type_idx locals instrs in
+  if export <> "" then add_export m export (ExportFunc func_idx);
+  func_idx

--- a/test/dune
+++ b/test/dune
@@ -37,3 +37,8 @@
  (name test_printer)
  (modules test_printer)
  (libraries axiom_lib alcotest))
+
+(test
+ (name test_wasm_encode)
+ (modules test_wasm_encode)
+ (libraries wasm_encode alcotest))

--- a/test/test_wasm_encode.ml
+++ b/test/test_wasm_encode.ml
@@ -1,0 +1,388 @@
+open Wasm_encode
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                             *)
+(* ------------------------------------------------------------------ *)
+
+(** Write bytes to a temp file, run [f path], delete the file. *)
+let with_tmp_wasm bytes f =
+  let path = Filename.temp_file "axiom_wasm_" ".wasm" in
+  let oc = open_out_bin path in
+  output_bytes oc bytes;
+  close_out oc;
+  let result = f path in
+  (try Sys.remove path with _ -> ());
+  result
+
+(** Validate a wasm binary using Node.js WebAssembly.validate.
+    Returns Ok () on success, Error msg on failure. *)
+let node_validate bytes =
+  with_tmp_wasm bytes (fun path ->
+    let quoted = Filename.quote path in
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         process.exit(WebAssembly.validate(buf)?0:1)"
+        quoted
+    in
+    let cmd = Printf.sprintf "node -e %s 2>/dev/null" (Filename.quote script) in
+    let rc = Sys.command cmd in
+    if rc = 0 then Ok ()
+    else Error (Printf.sprintf "WebAssembly.validate returned false (exit %d)" rc))
+
+(** Instantiate a wasm module with Node.js and call [func_name] (no args).
+    Returns the i32 result as an int, or Error msg. *)
+let node_run bytes func_name =
+  with_tmp_wasm bytes (fun path ->
+    let quoted = Filename.quote path in
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         WebAssembly.instantiate(buf).then(({instance})=>{\
+           const r=instance.exports[%s]();\
+           console.log(r);\
+           process.exit(0);\
+         }).catch(e=>{console.error(e.message);process.exit(1);})"
+        quoted
+        (Printf.sprintf "'%s'" func_name)
+    in
+    let tmp_out = Filename.temp_file "axiom_wasm_out_" ".txt" in
+    let cmd =
+      Printf.sprintf "node -e %s >%s 2>/dev/null"
+        (Filename.quote script)
+        (Filename.quote tmp_out)
+    in
+    let rc = Sys.command cmd in
+    let output =
+      let ic = open_in tmp_out in
+      let s = try input_line ic with End_of_file -> "" in
+      close_in ic;
+      (try Sys.remove tmp_out with _ -> ());
+      s
+    in
+    if rc <> 0 then Error (Printf.sprintf "node exited with %d" rc)
+    else
+      match int_of_string_opt (String.trim output) with
+      | Some n -> Ok n
+      | None   -> Error (Printf.sprintf "unexpected output: %S" output))
+
+(* ------------------------------------------------------------------ *)
+(* LEB128 unit tests                                                   *)
+(* ------------------------------------------------------------------ *)
+
+let leb_bytes f n =
+  let buf = Buffer.create 8 in
+  f buf n;
+  Buffer.to_bytes buf
+
+let test_uleb128_single () =
+  Alcotest.(check bytes) "uleb 0" (Bytes.of_string "\x00") (leb_bytes put_uleb128 0);
+  Alcotest.(check bytes) "uleb 1" (Bytes.of_string "\x01") (leb_bytes put_uleb128 1);
+  Alcotest.(check bytes) "uleb 63" (Bytes.of_string "\x3F") (leb_bytes put_uleb128 63);
+  Alcotest.(check bytes) "uleb 127" (Bytes.of_string "\x7F") (leb_bytes put_uleb128 127)
+
+let test_uleb128_multi () =
+  (* 128 = 0x80 0x01 in LEB128 *)
+  Alcotest.(check bytes) "uleb 128"
+    (Bytes.of_string "\x80\x01") (leb_bytes put_uleb128 128);
+  (* 300 = 0xAC 0x02 *)
+  Alcotest.(check bytes) "uleb 300"
+    (Bytes.of_string "\xAC\x02") (leb_bytes put_uleb128 300)
+
+let test_sleb128_positive () =
+  Alcotest.(check bytes) "sleb 0"  (Bytes.of_string "\x00") (leb_bytes put_sleb128 0);
+  Alcotest.(check bytes) "sleb 42" (Bytes.of_string "\x2A") (leb_bytes put_sleb128 42);
+  (* 64 needs two bytes: 0xC0 0x00 *)
+  Alcotest.(check bytes) "sleb 64"
+    (Bytes.of_string "\xC0\x00") (leb_bytes put_sleb128 64)
+
+let test_sleb128_negative () =
+  (* -1 = 0x7F *)
+  Alcotest.(check bytes) "sleb -1"  (Bytes.of_string "\x7F") (leb_bytes put_sleb128 (-1));
+  (* -128 = 0x80 0x7F *)
+  Alcotest.(check bytes) "sleb -128"
+    (Bytes.of_string "\x80\x7F") (leb_bytes put_sleb128 (-128))
+
+(* ------------------------------------------------------------------ *)
+(* Test 1: constant function  (func (result i32) i32.const 42)         *)
+(* ------------------------------------------------------------------ *)
+
+let build_answer_module () =
+  let m = create () in
+  let _ = add_function m ~export:"answer" [] [I32] [] [I32Const 42] in
+  encode m
+
+let test_constant_func_bytes () =
+  let wasm = build_answer_module () in
+  (* Magic + version *)
+  Alcotest.(check bytes) "magic"
+    (Bytes.of_string "\x00asm")
+    (Bytes.sub wasm 0 4);
+  Alcotest.(check int) "version word"
+    1
+    (Char.code (Bytes.get wasm 4) lor
+     (Char.code (Bytes.get wasm 5) lsl 8) lor
+     (Char.code (Bytes.get wasm 6) lsl 16) lor
+     (Char.code (Bytes.get wasm 7) lsl 24));
+  (* Section ids should appear in order: 1 (type), 3 (func), 7 (export), 10 (code) *)
+  let b i = Char.code (Bytes.get wasm i) in
+  Alcotest.(check int) "type section id"   1 (b 8);
+  (* Find function section after type section *)
+  let type_sec_size = b 9 in
+  let func_sec_offset = 8 + 2 + type_sec_size in
+  Alcotest.(check int) "func section id"   3 (b func_sec_offset);
+  ignore func_sec_offset
+
+let test_constant_func_valid () =
+  let wasm = build_answer_module () in
+  match node_validate wasm with
+  | Ok ()     -> ()
+  | Error msg -> Alcotest.fail ("wasm invalid: " ^ msg)
+
+let test_constant_func_runs () =
+  let wasm = build_answer_module () in
+  match node_run wasm "answer" with
+  | Ok 42     -> ()
+  | Ok n      -> Alcotest.failf "expected 42, got %d" n
+  | Error msg -> Alcotest.fail ("execution failed: " ^ msg)
+
+(* ------------------------------------------------------------------ *)
+(* Test 2: function with locals + arithmetic                            *)
+(*   (func (export "compute") (result i32)                             *)
+(*     (local i32)      ;; local 0                                     *)
+(*     i32.const 10                                                     *)
+(*     local.set 0                                                      *)
+(*     local.get 0                                                      *)
+(*     i32.const 32                                                     *)
+(*     i32.add)         ;; result: 42                                  *)
+(* ------------------------------------------------------------------ *)
+
+let build_locals_module () =
+  let m = create () in
+  let _ =
+    add_function m ~export:"compute" [] [I32]
+      [{ count = 1; ty = I32 }]
+      [ I32Const 10
+      ; LocalSet 0
+      ; LocalGet 0
+      ; I32Const 32
+      ; I32Add
+      ]
+  in
+  encode m
+
+let test_locals_valid () =
+  let wasm = build_locals_module () in
+  match node_validate wasm with
+  | Ok ()     -> ()
+  | Error msg -> Alcotest.fail ("wasm invalid: " ^ msg)
+
+let test_locals_runs () =
+  let wasm = build_locals_module () in
+  match node_run wasm "compute" with
+  | Ok 42     -> ()
+  | Ok n      -> Alcotest.failf "expected 42, got %d" n
+  | Error msg -> Alcotest.fail ("execution failed: " ^ msg)
+
+(* ------------------------------------------------------------------ *)
+(* Test 3: control flow — if/else                                       *)
+(*   (func (export "abs_diff") (param i32 i32) (result i32)            *)
+(*     local.get 0                                                      *)
+(*     local.get 1                                                      *)
+(*     i32.gt_s                                                         *)
+(*     if (result i32)                                                  *)
+(*       local.get 0  local.get 1  i32.sub                             *)
+(*     else                                                             *)
+(*       local.get 1  local.get 0  i32.sub                             *)
+(*     end)                                                             *)
+(* ------------------------------------------------------------------ *)
+
+let build_if_module () =
+  let m = create () in
+  let _ =
+    add_function m ~export:"abs_diff" [I32; I32] [I32] []
+      [ LocalGet 0
+      ; LocalGet 1
+      ; I32GtS
+      ; If (ValType I32,
+            [LocalGet 0; LocalGet 1; I32Sub],
+            Some [LocalGet 1; LocalGet 0; I32Sub])
+      ]
+  in
+  encode m
+
+let test_if_valid () =
+  let wasm = build_if_module () in
+  match node_validate wasm with
+  | Ok ()     -> ()
+  | Error msg -> Alcotest.fail ("wasm invalid: " ^ msg)
+
+let test_if_runs_pos () =
+  let wasm = build_if_module () in
+  (* abs_diff(10, 3) = 7 *)
+  with_tmp_wasm wasm (fun path ->
+    let quoted = Filename.quote path in
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         WebAssembly.instantiate(buf).then(({instance})=>{\
+           console.log(instance.exports.abs_diff(10,3));\
+         });"
+        quoted
+    in
+    let tmp = Filename.temp_file "axiom_wasm_if_" ".txt" in
+    ignore (Sys.command (Printf.sprintf "node -e %s >%s 2>/dev/null"
+                           (Filename.quote script) (Filename.quote tmp)));
+    let ic = open_in tmp in
+    let s = (try input_line ic with End_of_file -> "") in
+    close_in ic;
+    (try Sys.remove tmp with _ -> ());
+    Alcotest.(check string) "abs_diff(10,3)=7" "7" (String.trim s))
+
+(* ------------------------------------------------------------------ *)
+(* Test 4: loop / br_if — count down                                   *)
+(*   (func (export "sum_n") (param i32) (result i32)                   *)
+(*     (local i32)   ;; acc in local 1                                 *)
+(*     block $exit                                                      *)
+(*       loop $top                                                      *)
+(*         local.get 0  i32.const 0  i32.eq  br_if 1   ;; $exit        *)
+(*         local.get 1  local.get 0  i32.add  local.set 1              *)
+(*         local.get 0  i32.const 1  i32.sub  local.set 0              *)
+(*         br 0         ;; $top                                         *)
+(*       end                                                            *)
+(*     end                                                              *)
+(*     local.get 1)   ;; return acc                                     *)
+(* ------------------------------------------------------------------ *)
+
+let build_loop_module () =
+  let m = create () in
+  let _ =
+    add_function m ~export:"sum_n" [I32] [I32]
+      [{ count = 1; ty = I32 }]   (* local 1: accumulator *)
+      [ Block (Void,
+          [ Loop (Void,
+              [ LocalGet 0; I32Const 0; I32Eq; BrIf 1   (* exit block *)
+              ; LocalGet 1; LocalGet 0; I32Add; LocalSet 1
+              ; LocalGet 0; I32Const 1; I32Sub; LocalSet 0
+              ; Br 0                                     (* top of loop *)
+              ])
+          ])
+      ; LocalGet 1
+      ]
+  in
+  encode m
+
+let test_loop_valid () =
+  let wasm = build_loop_module () in
+  match node_validate wasm with
+  | Ok ()     -> ()
+  | Error msg -> Alcotest.fail ("wasm invalid: " ^ msg)
+
+let test_loop_runs () =
+  (* sum_n(10) = 55 *)
+  let wasm = build_loop_module () in
+  with_tmp_wasm wasm (fun path ->
+    let quoted = Filename.quote path in
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         WebAssembly.instantiate(buf).then(({instance})=>{\
+           console.log(instance.exports.sum_n(10));\
+         });"
+        quoted
+    in
+    let tmp = Filename.temp_file "axiom_wasm_loop_" ".txt" in
+    ignore (Sys.command (Printf.sprintf "node -e %s >%s 2>/dev/null"
+                           (Filename.quote script) (Filename.quote tmp)));
+    let ic = open_in tmp in
+    let s = (try input_line ic with End_of_file -> "") in
+    close_in ic;
+    (try Sys.remove tmp with _ -> ());
+    Alcotest.(check string) "sum_n(10)=55" "55" (String.trim s))
+
+(* ------------------------------------------------------------------ *)
+(* Test 5: call instruction                                            *)
+(*   (func $double (param i32) (result i32)                            *)
+(*     local.get 0  local.get 0  i32.add)                              *)
+(*   (func (export "quad") (param i32) (result i32)                    *)
+(*     local.get 0  call $double  call $double)                        *)
+(* ------------------------------------------------------------------ *)
+
+let build_call_module () =
+  let m = create () in
+  let double_idx =
+    add_function m [I32] [I32] []
+      [LocalGet 0; LocalGet 0; I32Add]
+  in
+  let _ =
+    add_function m ~export:"quad" [I32] [I32] []
+      [LocalGet 0; Call double_idx; Call double_idx]
+  in
+  encode m
+
+let test_call_valid () =
+  let wasm = build_call_module () in
+  match node_validate wasm with
+  | Ok ()     -> ()
+  | Error msg -> Alcotest.fail ("wasm invalid: " ^ msg)
+
+let test_call_runs () =
+  let wasm = build_call_module () in
+  with_tmp_wasm wasm (fun path ->
+    let quoted = Filename.quote path in
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         WebAssembly.instantiate(buf).then(({instance})=>{\
+           console.log(instance.exports.quad(3));\
+         });"
+        quoted
+    in
+    let tmp = Filename.temp_file "axiom_wasm_call_" ".txt" in
+    ignore (Sys.command (Printf.sprintf "node -e %s >%s 2>/dev/null"
+                           (Filename.quote script) (Filename.quote tmp)));
+    let ic = open_in tmp in
+    let s = (try input_line ic with End_of_file -> "") in
+    close_in ic;
+    (try Sys.remove tmp with _ -> ());
+    Alcotest.(check string) "quad(3)=12" "12" (String.trim s))
+
+(* ------------------------------------------------------------------ *)
+(* Test suite registration                                             *)
+(* ------------------------------------------------------------------ *)
+
+let () =
+  Alcotest.run "wasm_encode"
+    [ ( "leb128",
+        [ Alcotest.test_case "uleb128 single byte" `Quick test_uleb128_single
+        ; Alcotest.test_case "uleb128 multi byte"  `Quick test_uleb128_multi
+        ; Alcotest.test_case "sleb128 positive"    `Quick test_sleb128_positive
+        ; Alcotest.test_case "sleb128 negative"    `Quick test_sleb128_negative
+        ] )
+    ; ( "constant_func",
+        [ Alcotest.test_case "byte layout"  `Quick test_constant_func_bytes
+        ; Alcotest.test_case "wasm-validate" `Quick test_constant_func_valid
+        ; Alcotest.test_case "executes 42"   `Quick test_constant_func_runs
+        ] )
+    ; ( "locals_and_arithmetic",
+        [ Alcotest.test_case "wasm-validate" `Quick test_locals_valid
+        ; Alcotest.test_case "executes 42"   `Quick test_locals_runs
+        ] )
+    ; ( "if_else",
+        [ Alcotest.test_case "wasm-validate"      `Quick test_if_valid
+        ; Alcotest.test_case "abs_diff(10,3)=7"   `Quick test_if_runs_pos
+        ] )
+    ; ( "loop_and_br",
+        [ Alcotest.test_case "wasm-validate"  `Quick test_loop_valid
+        ; Alcotest.test_case "sum_n(10)=55"   `Quick test_loop_runs
+        ] )
+    ; ( "call",
+        [ Alcotest.test_case "wasm-validate" `Quick test_call_valid
+        ; Alcotest.test_case "quad(3)=12"    `Quick test_call_runs
+        ] )
+    ]


### PR DESCRIPTION
## Summary
Implement a complete WebAssembly binary encoder supporting the instruction subset required for Milestone 1 code generation. This includes LEB128 encoding primitives, per-section encoders, a structured instruction type, and a module builder API for incrementally constructing WASM modules.

## Key Changes

- **New module `lib/wasm/wasm_encode.ml`**: Complete WASM binary encoder with:
  - Type definitions for `val_type`, `block_type`, `instr`, `func_type`, `export_desc`, `import_desc`, `global_init`, `limits`, `data_segment`, `elem_segment`, and `module_builder`
  - LEB128 encoding helpers (`put_uleb128`, `put_sleb128`) for variable-length integer encoding
  - Instruction encoder supporting: constants, arithmetic (add/sub/mul), comparisons (eq/lt_s/gt_s), local operations (get/set/tee), control flow (if/else, block, loop, br/br_if/br_table), function calls, and stack operations (drop/return)
  - Per-section encoders for all required WASM sections (type, import, function, table, memory, global, export, code, element, data, start)
  - Module builder API with methods to incrementally add types, imports, functions, tables, memories, globals, exports, elements, and data segments
  - Full module encoding that emits valid WASM binaries with proper section ordering and size prefixes

- **New test suite `test/test_wasm_encode.ml`**: Comprehensive validation tests including:
  - LEB128 encoding unit tests (single/multi-byte, signed/unsigned)
  - Integration tests that generate WASM modules and validate them using Node.js `WebAssembly.validate()`
  - Execution tests that instantiate modules and verify correct runtime behavior:
    - Simple constant function returning 42
    - Local variables and arithmetic operations
    - Control flow with if/else (absolute difference calculation)
    - Loops with conditional breaks (sum 1..n)
    - Function calls with multiple levels of indirection
  - Helper functions for temporary file handling and Node.js integration

- **Build configuration**: Added `lib/wasm/dune` to define the `wasm_encode` library and updated `test/dune` to include the new test suite

## Implementation Details

- LEB128 encoding handles both unsigned (for counts/sizes) and signed (for immediates/indices) variants with proper continuation bit handling
- Instruction encoding is recursive to support nested control structures (if/block/loop)
- Section emission uses a two-pass approach: encode content to a temporary buffer, then emit section ID, size (as uleb128), and content
- Module builder maintains separate lists for types, imports, functions, tables, memories, globals, exports, elements, and bodies, enabling flexible module construction
- Function indices correctly account for imported functions when computing local function indices
- All generated WASM modules are validated against the WebAssembly specification and tested for correct execution behavior

https://claude.ai/code/session_0188i6j6caUcgEQAmcwjTftT