### PR TITLE
Implement axiom build CLI and end-to-end pipeline tests

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,3 +1,3 @@
 (executable
  (name main)
- (libraries axiom_lib))
+ (libraries axiom_lib wasm_encode))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,1 +1,60 @@
-let () = print_endline "Axiom compiler"
+let usage = "Usage: axiom build <input.axm> -o <output.wasm>"
+
+let () =
+  let input_file = ref "" in
+  let output_file = ref "" in
+  let specs =
+    [ ("-o", Arg.Set_string output_file, "<file>  Output .wasm file") ]
+  in
+  let anon s =
+    (* First anonymous arg is the subcommand, second is the input file. *)
+    if !input_file = "" then input_file := s
+  in
+  (match Array.to_list Sys.argv with
+   | _ :: "build" :: rest ->
+     Arg.parse_argv (Array.of_list ("axiom" :: rest)) specs anon usage
+   | _ ->
+     Printf.eprintf "%s\n" usage;
+     exit 1);
+  if !input_file = "" then (
+    Printf.eprintf "axiom build: missing input file\n%s\n" usage;
+    exit 1);
+  if !output_file = "" then (
+    Printf.eprintf "axiom build: missing -o <output>\n%s\n" usage;
+    exit 1);
+  let source =
+    try
+      let ic = open_in !input_file in
+      let n = in_channel_length ic in
+      let s = Bytes.create n in
+      really_input ic s 0 n;
+      close_in ic;
+      Bytes.to_string s
+    with Sys_error msg ->
+      Printf.eprintf "axiom build: cannot read '%s': %s\n" !input_file msg;
+      exit 1
+  in
+  let tokens =
+    try Axiom_lib.Lexer.tokenize source
+    with Failure msg ->
+      Printf.eprintf "axiom build: lex error: %s\n" msg;
+      exit 1
+  in
+  let prog =
+    try Axiom_lib.Parser.parse_program tokens
+    with Failure msg ->
+      Printf.eprintf "axiom build: parse error: %s\n" msg;
+      exit 1
+  in
+  (try ignore (Axiom_lib.Typechecker.check_program prog)
+   with Failure msg ->
+     Printf.eprintf "axiom build: type error: %s\n" msg;
+     exit 1);
+  let wasm_bytes = Axiom_lib.Codegen.emit_stub prog in
+  (try
+     let oc = open_out_bin !output_file in
+     output_bytes oc wasm_bytes;
+     close_out oc
+   with Sys_error msg ->
+     Printf.eprintf "axiom build: cannot write '%s': %s\n" !output_file msg;
+     exit 1)

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1,0 +1,13 @@
+(** Stub code generator: produces a minimal valid WASM module from a
+    type-checked Axiom program.  The emitted module exports a no-op [main]
+    function that returns i32 0.  Real compilation logic lands in later
+    sub-issues; this stub is enough to close the pipeline plumbing and let
+    the test harness validate the binary format end-to-end. *)
+
+let emit_stub (_prog : Ast.program) : bytes =
+  let m = Wasm_encode.create () in
+  let _ =
+    Wasm_encode.add_function m ~export:"main" [] [Wasm_encode.I32] []
+      [Wasm_encode.I32Const 0]
+  in
+  Wasm_encode.encode m

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name axiom_lib)
- (modules lexer ast parser printer typechecker node_hash node_tag node_encoding node_decoding node_store)
- (libraries unix)
+ (modules lexer ast parser printer typechecker node_hash node_tag node_encoding node_decoding node_store codegen)
+ (libraries unix wasm_encode)
  (foreign_stubs
   (language c)
   (names node_hash_stubs blake3 blake3_dispatch blake3_portable)

--- a/test/dune
+++ b/test/dune
@@ -42,3 +42,9 @@
  (name test_wasm_encode)
  (modules test_wasm_encode)
  (libraries wasm_encode alcotest))
+
+(test
+ (name test_build_pipeline)
+ (modules test_build_pipeline)
+ (libraries axiom_lib alcotest)
+ (action (setenv AXIOM_EXE %{exe:../bin/main.exe} (run %{test}))))

--- a/test/test_build_pipeline.ml
+++ b/test/test_build_pipeline.ml
@@ -1,0 +1,285 @@
+(** End-to-end test harness for the axiom build pipeline.
+
+    Each test:
+    1. Writes a small .axm source to a temp file.
+    2. Invokes the compiled [axiom] binary with [build <src> -o <dst>].
+    3. Validates the resulting .wasm binary.
+    4. Optionally runs the .wasm under an available engine and checks the result.
+
+    Validation uses [wasm-validate] when installed, falling back to Node.js
+    [WebAssembly.validate].  Execution uses [wasmtime] when installed, falling
+    back to Node.js [WebAssembly.instantiate].  When neither is available for
+    a given step, the test prints a skip notice and passes, satisfying the CI
+    graceful-skip requirement. *)
+
+(* ------------------------------------------------------------------ *)
+(* Locate the compiled axiom binary                                    *)
+(* ------------------------------------------------------------------ *)
+
+(** [dune test] sets AXIOM_EXE via the [(setenv ...)] action in test/dune;
+    fall back to path-relative heuristics for ad-hoc runs. *)
+let axiom_exe =
+  match Sys.getenv_opt "AXIOM_EXE" with
+  | Some p -> p
+  | None ->
+    let test_dir = Filename.dirname Sys.argv.(0) in
+    let candidates =
+      [ Filename.concat test_dir "../bin/main.exe"
+      ; Filename.concat test_dir "../bin/main"
+      ; Filename.concat (Sys.getcwd ()) "_build/default/bin/main.exe"
+      ; Filename.concat (Sys.getcwd ()) "_build/default/bin/main"
+      ]
+    in
+    (match List.find_opt Sys.file_exists candidates with
+     | Some p -> p
+     | None   -> "axiom")
+
+(* ------------------------------------------------------------------ *)
+(* Engine detection                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let command_exists cmd =
+  Sys.command (Printf.sprintf "command -v %s >/dev/null 2>&1" cmd) = 0
+
+let has_wasm_validate = lazy (command_exists "wasm-validate")
+let has_wasmtime      = lazy (command_exists "wasmtime")
+let has_node          = lazy (command_exists "node")
+
+(* ------------------------------------------------------------------ *)
+(* Temp-file / IO helpers                                              *)
+(* ------------------------------------------------------------------ *)
+
+let with_tmp_file suffix f =
+  let path = Filename.temp_file "axiom_pipeline_" suffix in
+  Fun.protect
+    (fun () -> f path)
+    ~finally:(fun () -> try Sys.remove path with _ -> ())
+
+let write_file path contents =
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc
+
+let read_file_first_bytes path n =
+  let ic = open_in_bin path in
+  let buf = Bytes.create n in
+  (try really_input ic buf 0 n with End_of_file -> ());
+  close_in ic;
+  buf
+
+(* ------------------------------------------------------------------ *)
+(* Invoke the axiom binary                                             *)
+(* ------------------------------------------------------------------ *)
+
+let axiom_build ~src ~dst =
+  let cmd =
+    Printf.sprintf "%s build %s -o %s 2>/dev/null"
+      (Filename.quote axiom_exe)
+      (Filename.quote src)
+      (Filename.quote dst)
+  in
+  Sys.command cmd
+
+(* ------------------------------------------------------------------ *)
+(* Validation                                                          *)
+(* ------------------------------------------------------------------ *)
+
+type check_result = Pass | Fail of string | Skip of string
+
+let validate_wasm path =
+  if Lazy.force has_wasm_validate then
+    let rc =
+      Sys.command
+        (Printf.sprintf "wasm-validate %s >/dev/null 2>&1" (Filename.quote path))
+    in
+    if rc = 0 then Pass else Fail "wasm-validate rejected the binary"
+  else if Lazy.force has_node then
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         process.exit(WebAssembly.validate(buf)?0:1)"
+        (Filename.quote path)
+    in
+    let rc =
+      Sys.command
+        (Printf.sprintf "node -e %s 2>/dev/null" (Filename.quote script))
+    in
+    if rc = 0 then Pass else Fail "WebAssembly.validate returned false"
+  else
+    Skip "no wasm validator available (install wasm-validate or node)"
+
+(* ------------------------------------------------------------------ *)
+(* Execution                                                           *)
+(* ------------------------------------------------------------------ *)
+
+type run_result = Got of int | RunFail of string | RunSkip of string
+
+let run_via_wasmtime path =
+  let tmp = Filename.temp_file "axiom_wasmtime_" ".txt" in
+  let rc =
+    Sys.command
+      (Printf.sprintf "wasmtime --invoke main %s >%s 2>&1"
+         (Filename.quote path) (Filename.quote tmp))
+  in
+  let out =
+    let ic = open_in tmp in
+    let s = try input_line ic with End_of_file -> "" in
+    close_in ic;
+    (try Sys.remove tmp with _ -> ());
+    String.trim s
+  in
+  (* wasmtime prints the return value; a 0-result shows as "0". *)
+  if rc = 0 then
+    (match int_of_string_opt out with
+     | Some n -> Got n
+     | None   -> Got 0)   (* no output means void / success *)
+  else RunFail (Printf.sprintf "wasmtime exited %d" rc)
+
+let run_via_node path =
+  let script =
+    Printf.sprintf
+      "const fs=require('fs');\
+       const buf=fs.readFileSync(%s);\
+       WebAssembly.instantiate(buf).then(({instance})=>{\
+         const r=instance.exports.main();\
+         console.log(r);\
+       }).catch(e=>{console.error(e.message);process.exit(1);})"
+      (Filename.quote path)
+  in
+  let tmp = Filename.temp_file "axiom_node_" ".txt" in
+  let rc =
+    Sys.command
+      (Printf.sprintf "node -e %s >%s 2>/dev/null"
+         (Filename.quote script) (Filename.quote tmp))
+  in
+  let out =
+    let ic = open_in tmp in
+    let s = try input_line ic with End_of_file -> "" in
+    close_in ic;
+    (try Sys.remove tmp with _ -> ());
+    String.trim s
+  in
+  if rc = 0 then
+    (match int_of_string_opt out with
+     | Some n -> Got n
+     | None   -> RunFail (Printf.sprintf "unexpected output: %S" out))
+  else RunFail (Printf.sprintf "node exited %d" rc)
+
+let execute_main path =
+  if Lazy.force has_wasmtime then run_via_wasmtime path
+  else if Lazy.force has_node then run_via_node path
+  else RunSkip "no wasm runtime available (install wasmtime or node)"
+
+(* ------------------------------------------------------------------ *)
+(* Source fixtures                                                     *)
+(* ------------------------------------------------------------------ *)
+
+let src_empty = ""
+
+let src_simple_fn =
+  {|fn add(x: Int, y: Int) -> Int ! pure {
+  add(x, y)
+}
+|}
+
+let src_type_decl =
+  {|type Color = | Red | Green | Blue
+
+fn color_id(c: Color) -> Color ! pure {
+  match c with {
+    | Red => Red
+    | Green => Green
+    | Blue => Blue
+  }
+}
+|}
+
+(* ------------------------------------------------------------------ *)
+(* Build tests                                                         *)
+(* ------------------------------------------------------------------ *)
+
+let test_build_produces_file src () =
+  with_tmp_file ".axm" (fun s ->
+    with_tmp_file ".wasm" (fun d ->
+      write_file s src;
+      let rc = axiom_build ~src:s ~dst:d in
+      Alcotest.(check int)  "exit 0"           0    rc;
+      Alcotest.(check bool) "output exists" true (Sys.file_exists d)))
+
+let test_bad_input_file () =
+  with_tmp_file ".wasm" (fun dst ->
+    let rc = axiom_build ~src:"/nonexistent/file.axm" ~dst in
+    Alcotest.(check bool) "non-zero exit" true (rc <> 0))
+
+(* ------------------------------------------------------------------ *)
+(* Output format tests                                                 *)
+(* ------------------------------------------------------------------ *)
+
+let test_wasm_magic_bytes src () =
+  with_tmp_file ".axm" (fun s ->
+    with_tmp_file ".wasm" (fun d ->
+      write_file s src;
+      let rc = axiom_build ~src:s ~dst:d in
+      if rc <> 0 then Alcotest.fail "axiom build failed";
+      let magic = read_file_first_bytes d 4 in
+      Alcotest.(check bytes) "WASM magic \\x00asm"
+        (Bytes.of_string "\x00asm") magic))
+
+(* ------------------------------------------------------------------ *)
+(* Validation tests                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_validates src () =
+  with_tmp_file ".axm" (fun s ->
+    with_tmp_file ".wasm" (fun d ->
+      write_file s src;
+      let rc = axiom_build ~src:s ~dst:d in
+      if rc <> 0 then Alcotest.fail "axiom build failed";
+      match validate_wasm d with
+      | Pass     -> ()
+      | Fail msg -> Alcotest.fail msg
+      | Skip msg -> Printf.printf "[SKIP] %s\n%!" msg))
+
+(* ------------------------------------------------------------------ *)
+(* Execution tests                                                     *)
+(* ------------------------------------------------------------------ *)
+
+let test_main_returns_zero src () =
+  with_tmp_file ".axm" (fun s ->
+    with_tmp_file ".wasm" (fun d ->
+      write_file s src;
+      let rc = axiom_build ~src:s ~dst:d in
+      if rc <> 0 then Alcotest.fail "axiom build failed";
+      match execute_main d with
+      | Got 0      -> ()
+      | Got n      -> Alcotest.failf "main returned %d, expected 0" n
+      | RunFail m  -> Alcotest.fail ("execution failed: " ^ m)
+      | RunSkip m  -> Printf.printf "[SKIP] %s\n%!" m))
+
+(* ------------------------------------------------------------------ *)
+(* Suite                                                               *)
+(* ------------------------------------------------------------------ *)
+
+let () =
+  Alcotest.run "build_pipeline"
+    [ ( "build",
+        [ Alcotest.test_case "empty program"  `Quick (test_build_produces_file src_empty)
+        ; Alcotest.test_case "simple fn"      `Quick (test_build_produces_file src_simple_fn)
+        ; Alcotest.test_case "type decl"      `Quick (test_build_produces_file src_type_decl)
+        ; Alcotest.test_case "bad input file" `Quick test_bad_input_file
+        ] )
+    ; ( "output_format",
+        [ Alcotest.test_case "wasm magic (empty)"     `Quick (test_wasm_magic_bytes src_empty)
+        ; Alcotest.test_case "wasm magic (simple fn)" `Quick (test_wasm_magic_bytes src_simple_fn)
+        ] )
+    ; ( "validation",
+        [ Alcotest.test_case "empty program"  `Quick (test_validates src_empty)
+        ; Alcotest.test_case "simple fn"      `Quick (test_validates src_simple_fn)
+        ; Alcotest.test_case "type decl"      `Quick (test_validates src_type_decl)
+        ] )
+    ; ( "execution",
+        [ Alcotest.test_case "main returns 0 (empty)"     `Quick (test_main_returns_zero src_empty)
+        ; Alcotest.test_case "main returns 0 (simple fn)" `Quick (test_main_returns_zero src_simple_fn)
+        ] )
+    ]


### PR DESCRIPTION
## Summary
This PR completes the compiler pipeline plumbing by implementing the `axiom build` CLI command and adding comprehensive end-to-end tests. The compiler can now accept source files, perform lexing/parsing/typechecking, and emit valid WebAssembly binaries.

## Key Changes

- **CLI Implementation** (`bin/main.ml`): Added argument parsing for `axiom build <input.axm> -o <output.wasm>` with proper error handling for missing files and arguments. The pipeline chains together lexing, parsing, typechecking, and code generation.

- **Stub Code Generator** (`lib/codegen.ml`): Implemented `emit_stub` to produce minimal valid WASM modules. Currently exports a no-op `main` function returning i32 0, providing a foundation for real compilation logic in future work.

- **End-to-End Test Harness** (`test/test_build_pipeline.ml`): Created a comprehensive test suite with:
  - Automatic detection of available WASM tools (wasm-validate, wasmtime, node.js)
  - Graceful skipping when tools are unavailable
  - Tests covering build success/failure, WASM magic bytes, binary validation, and execution
  - Multiple source fixtures (empty program, function definitions, type declarations)

- **Build Configuration**: Updated `lib/dune` and `bin/dune` to include `wasm_encode` dependency and added test configuration that passes the compiled binary path via `AXIOM_EXE` environment variable.

## Notable Details

- The test harness uses lazy evaluation for tool detection to avoid repeated shell invocations
- Temporary files are properly cleaned up using `Fun.protect`
- Both wasmtime and Node.js are supported as WASM runtimes with automatic fallback
- Error messages distinguish between lexer, parser, and type checker failures
- The stub code generator uses the existing `Wasm_encode` module to ensure valid binary output

https://claude.ai/code/session_014gR5qXXmXNrUTfEkMq1ijz