### PR TITLE
Implement Milestone 1 code generation: literals, arithmetic, let-bindings

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -50,7 +50,7 @@ let () =
    with Failure msg ->
      Printf.eprintf "axiom build: type error: %s\n" msg;
      exit 1);
-  let wasm_bytes = Axiom_lib.Codegen.emit_stub prog in
+  let wasm_bytes = Axiom_lib.Codegen.emit prog in
   (try
      let oc = open_out_bin !output_file in
      output_bytes oc wasm_bytes;

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1,13 +1,95 @@
-(** Stub code generator: produces a minimal valid WASM module from a
-    type-checked Axiom program.  The emitted module exports a no-op [main]
-    function that returns i32 0.  Real compilation logic lands in later
-    sub-issues; this stub is enough to close the pipeline plumbing and let
-    the test harness validate the binary format end-to-end. *)
+(** Code generator: translates type-checked Axiom programs to WASM binary.
 
-let emit_stub (_prog : Ast.program) : bytes =
-  let m = Wasm_encode.create () in
-  let _ =
-    Wasm_encode.add_function m ~export:"main" [] [Wasm_encode.I32] []
-      [Wasm_encode.I32Const 0]
+    Milestone 1 scope: Int literals (i32.const), arithmetic primitives
+    add/sub/mul (i32.add/sub/mul), and let-bindings (fresh locals). The
+    special function [main : () -> Int ! pure] is exported as the module
+    entry point.  All other top-level declarations are ignored for now. *)
+
+open Wasm_encode
+
+(* ------------------------------------------------------------------ *)
+(* Per-function compilation state                                       *)
+(* ------------------------------------------------------------------ *)
+
+type ctx = {
+  env          : (string * int) list;   (** variable name -> local index *)
+  next_local   : int ref;               (** next free local slot *)
+  extra_locals : local_decl list ref;   (** additional locals beyond params *)
+}
+
+let make_ctx params =
+  { env          = List.mapi (fun i (name, _) -> (name, i)) params
+  ; next_local   = ref (List.length params)
+  ; extra_locals = ref []
+  }
+
+(** Allocate a fresh i32 local; returns its index. *)
+let alloc_local ctx =
+  let idx = !(ctx.next_local) in
+  incr ctx.next_local;
+  ctx.extra_locals := !(ctx.extra_locals) @ [{ count = 1; ty = I32 }];
+  idx
+
+(* ------------------------------------------------------------------ *)
+(* Expression compiler                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let rec compile_expr ctx expr =
+  match expr.Ast.desc with
+  | Ast.IntLit n ->
+    [I32Const (Int64.to_int n)]
+
+  | Ast.Var x ->
+    (match List.assoc_opt x ctx.env with
+     | Some idx -> [LocalGet idx]
+     | None     -> failwith ("Codegen: unbound variable: " ^ x))
+
+  | Ast.App ({ Ast.desc = Ast.Var op; _ }, [a; b]) ->
+    let binop = match op with
+      | "add" -> I32Add
+      | "sub" -> I32Sub
+      | "mul" -> I32Mul
+      | other -> failwith ("Codegen: unknown primitive: " ^ other)
+    in
+    compile_expr ctx a @ compile_expr ctx b @ [binop]
+
+  | Ast.Let { pat = { Ast.pat_desc = Ast.PVar x; _ }; value; body } ->
+    let idx         = alloc_local ctx in
+    let value_code  = compile_expr ctx value in
+    let body_code   = compile_expr { ctx with env = (x, idx) :: ctx.env } body in
+    value_code @ [LocalSet idx] @ body_code
+
+  | other ->
+    failwith (Format.asprintf "Codegen: unsupported expression: %a"
+                Ast.pp_expr_desc other)
+
+(* ------------------------------------------------------------------ *)
+(* Function compiler                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let compile_fn (m : module_builder) ~export
+    ~(params : (string * val_type) list) (body : Ast.expr) =
+  let ctx = make_ctx params in
+  let instrs = compile_expr ctx body in
+  ignore (add_function m ~export (List.map snd params) [I32]
+            !(ctx.extra_locals) instrs)
+
+(* ------------------------------------------------------------------ *)
+(* Module emitter                                                       *)
+(* ------------------------------------------------------------------ *)
+
+let emit (prog : Ast.program) : bytes =
+  let m = create () in
+  let main_decl =
+    List.find_opt (fun d -> match d.Ast.decl_desc with
+      | Ast.DeclFn { fn_name = "main"; _ } -> true
+      | _ -> false) prog
   in
-  Wasm_encode.encode m
+  (match main_decl with
+   | Some { Ast.decl_desc = Ast.DeclFn { decl_body; _ }; _ } ->
+     compile_fn m ~export:"main" ~params:[] decl_body
+   | _ ->
+     ignore (add_function m ~export:"main" [] [I32] [] [I32Const 0]));
+  encode m
+
+let emit_stub = emit

--- a/test/test_build_pipeline.ml
+++ b/test/test_build_pipeline.ml
@@ -195,6 +195,20 @@ fn color_id(c: Color) -> Color ! pure {
 }
 |}
 
+(* Issue #34: Int literals, arithmetic primitives, and let bindings *)
+let src_main_add_literals =
+  {|fn main() -> Int ! pure {
+  add(1, 2)
+}|}
+
+let src_main_let_arithmetic =
+  {|fn main() -> Int ! pure {
+  let a = add(3, 4) in
+  let b = mul(a, 2) in
+  sub(b, 1)
+}|}
+(* a = 7, b = 14, result = 13 *)
+
 (* ------------------------------------------------------------------ *)
 (* Build tests                                                         *)
 (* ------------------------------------------------------------------ *)
@@ -257,6 +271,18 @@ let test_main_returns_zero src () =
       | RunFail m  -> Alcotest.fail ("execution failed: " ^ m)
       | RunSkip m  -> Printf.printf "[SKIP] %s\n%!" m))
 
+let test_main_returns src expected () =
+  with_tmp_file ".axm" (fun s ->
+    with_tmp_file ".wasm" (fun d ->
+      write_file s src;
+      let rc = axiom_build ~src:s ~dst:d in
+      if rc <> 0 then Alcotest.fail "axiom build failed";
+      match execute_main d with
+      | Got n when n = expected -> ()
+      | Got n     -> Alcotest.failf "main returned %d, expected %d" n expected
+      | RunFail m -> Alcotest.fail ("execution failed: " ^ m)
+      | RunSkip m -> Printf.printf "[SKIP] %s\n%!" m))
+
 (* ------------------------------------------------------------------ *)
 (* Suite                                                               *)
 (* ------------------------------------------------------------------ *)
@@ -281,5 +307,9 @@ let () =
     ; ( "execution",
         [ Alcotest.test_case "main returns 0 (empty)"     `Quick (test_main_returns_zero src_empty)
         ; Alcotest.test_case "main returns 0 (simple fn)" `Quick (test_main_returns_zero src_simple_fn)
+        ] )
+    ; ( "codegen",
+        [ Alcotest.test_case "add(1,2) = 3"           `Quick (test_main_returns src_main_add_literals 3)
+        ; Alcotest.test_case "let+arithmetic = 13"    `Quick (test_main_returns src_main_let_arithmetic 13)
         ] )
     ]


### PR DESCRIPTION
## Summary
Replace the stub code generator with a functional implementation that compiles Axiom programs to WASM binary. This milestone adds support for integer literals, arithmetic primitives (add/sub/mul), and let-bindings with local variable allocation.

## Key Changes

- **Expression compiler**: Implemented `compile_expr` to handle:
  - Integer literals (`i32.const`)
  - Variable references with environment lookup
  - Binary arithmetic operations (add, sub, mul) via primitive function calls
  - Let-bindings with fresh local allocation and environment extension

- **Compilation context**: Added `ctx` type to track:
  - Variable name-to-local-index mapping
  - Next available local slot counter
  - Additional local declarations beyond function parameters

- **Local allocation**: Implemented `alloc_local` to manage fresh i32 locals for let-bound variables

- **Function compiler**: Updated `compile_fn` to:
  - Build compilation context from function parameters
  - Compile function body to instruction sequence
  - Include allocated locals in function signature

- **Module emitter**: Changed `emit` to:
  - Search for `main` function declaration in program
  - Compile main's body if found, otherwise emit stub (returns 0)
  - Fallback to no-op main for programs without main declaration

- **Test coverage**: Added two integration tests:
  - `add(1, 2)` → expects 3
  - Nested let-bindings with arithmetic → expects 13

## Implementation Details

The compiler uses a recursive descent approach for expressions, building instruction sequences that are concatenated. Let-bindings allocate fresh locals and extend the environment for their body scope. The main function is identified by name and exported as the module entry point.

https://claude.ai/code/session_01HsL8XLi9RHKosatakSQSVb