### PR TITLE
Codegen for top-level functions and direct/recursive calls

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1,11 +1,28 @@
 (** Code generator: translates type-checked Axiom programs to WASM binary.
 
-    Milestone 1 scope: Int literals (i32.const), arithmetic primitives
-    add/sub/mul (i32.add/sub/mul), and let-bindings (fresh locals). The
-    special function [main : () -> Int ! pure] is exported as the module
-    entry point.  All other top-level declarations are ignored for now. *)
+    Issue #35 scope: top-level function definitions with direct and mutually
+    recursive calls.  A two-pass approach pre-registers all function
+    signatures before compiling any body so recursive and forward references
+    resolve correctly.  Letrec expressions are lowered to additional module
+    functions using the same mechanism.
+
+    Milestone 1 type support: Int and Bool map to i32; all others are
+    skipped at the top level so that earlier tests remain unaffected. *)
 
 open Wasm_encode
+
+(* ------------------------------------------------------------------ *)
+(* Type conversion                                                      *)
+(* ------------------------------------------------------------------ *)
+
+let val_type_of_type_expr = function
+  | Ast.TyName "Int"  -> I32
+  | Ast.TyName "Bool" -> I32
+  | _ -> failwith "Codegen: unsupported type"
+
+let is_supported_type = function
+  | Ast.TyName "Int" | Ast.TyName "Bool" -> true
+  | _ -> false
 
 (* ------------------------------------------------------------------ *)
 (* Per-function compilation state                                       *)
@@ -15,20 +32,41 @@ type ctx = {
   env          : (string * int) list;   (** variable name -> local index *)
   next_local   : int ref;               (** next free local slot *)
   extra_locals : local_decl list ref;   (** additional locals beyond params *)
+  func_map     : (string * int) list;   (** function name -> wasm func index *)
+  module_      : module_builder;
+  (** Accumulator for (func_idx, locals, instrs); sorted and flushed in emit. *)
+  pending      : (int * local_decl list * instr list) list ref;
 }
 
-let make_ctx params =
+let make_ctx params func_map module_ pending =
   { env          = List.mapi (fun i (name, _) -> (name, i)) params
   ; next_local   = ref (List.length params)
   ; extra_locals = ref []
+  ; func_map     = func_map
+  ; module_      = module_
+  ; pending      = pending
   }
 
-(** Allocate a fresh i32 local; returns its index. *)
 let alloc_local ctx =
   let idx = !(ctx.next_local) in
   incr ctx.next_local;
   ctx.extra_locals := !(ctx.extra_locals) @ [{ count = 1; ty = I32 }];
   idx
+
+(* ------------------------------------------------------------------ *)
+(* Primitive binary operations                                          *)
+(* ------------------------------------------------------------------ *)
+
+let primitives = ["add"; "sub"; "mul"; "eq"; "lt"; "gt"]
+
+let instr_of_prim = function
+  | "add" -> I32Add
+  | "sub" -> I32Sub
+  | "mul" -> I32Mul
+  | "eq"  -> I32Eq
+  | "lt"  -> I32LtS
+  | "gt"  -> I32GtS
+  | _     -> assert false
 
 (* ------------------------------------------------------------------ *)
 (* Expression compiler                                                  *)
@@ -44,52 +82,128 @@ let rec compile_expr ctx expr =
      | Some idx -> [LocalGet idx]
      | None     -> failwith ("Codegen: unbound variable: " ^ x))
 
-  | Ast.App ({ Ast.desc = Ast.Var op; _ }, [a; b]) ->
-    let binop = match op with
-      | "add" -> I32Add
-      | "sub" -> I32Sub
-      | "mul" -> I32Mul
-      | other -> failwith ("Codegen: unknown primitive: " ^ other)
-    in
-    compile_expr ctx a @ compile_expr ctx b @ [binop]
+  (* Known binary primitives — matched before the general App case *)
+  | Ast.App ({ Ast.desc = Ast.Var op; _ }, [a; b])
+    when List.mem op primitives ->
+    compile_expr ctx a @ compile_expr ctx b @ [instr_of_prim op]
+
+  (* General function call via Call instruction *)
+  | Ast.App ({ Ast.desc = Ast.Var name; _ }, args) ->
+    (match List.assoc_opt name ctx.func_map with
+     | Some idx ->
+       List.concat_map (compile_expr ctx) args @ [Call idx]
+     | None ->
+       failwith ("Codegen: unknown function: " ^ name))
 
   | Ast.Let { pat = { Ast.pat_desc = Ast.PVar x; _ }; value; body } ->
-    let idx         = alloc_local ctx in
-    let value_code  = compile_expr ctx value in
-    let body_code   = compile_expr { ctx with env = (x, idx) :: ctx.env } body in
+    let idx        = alloc_local ctx in
+    let value_code = compile_expr ctx value in
+    let body_code  = compile_expr { ctx with env = (x, idx) :: ctx.env } body in
     value_code @ [LocalSet idx] @ body_code
+
+  | Ast.If { cond; then_; else_ } ->
+    compile_expr ctx cond @
+    [If (ValType I32,
+         compile_expr ctx then_,
+         Some (compile_expr ctx else_))]
+
+  | Ast.Do stmts ->
+    compile_do ctx stmts
+
+  | Ast.Letrec (bindings, body) ->
+    compile_letrec ctx bindings body
 
   | other ->
     failwith (Format.asprintf "Codegen: unsupported expression: %a"
                 Ast.pp_expr_desc other)
 
-(* ------------------------------------------------------------------ *)
-(* Function compiler                                                    *)
-(* ------------------------------------------------------------------ *)
+(* Sequential do-block: all but the last statement drop their value. *)
+and compile_do ctx stmts =
+  match stmts with
+  | [] -> failwith "Codegen: empty do block"
+  | [Ast.StmtExpr e] ->
+    compile_expr ctx e
+  | Ast.StmtLet { pat = { Ast.pat_desc = Ast.PVar x; _ }; value } :: rest ->
+    let idx = alloc_local ctx in
+    compile_expr ctx value
+    @ [LocalSet idx]
+    @ compile_do { ctx with env = (x, idx) :: ctx.env } rest
+  | Ast.StmtExpr e :: rest ->
+    compile_expr ctx e @ [Drop] @ compile_do ctx rest
+  | _ ->
+    failwith "Codegen: unsupported do statement"
 
-let compile_fn (m : module_builder) ~export
-    ~(params : (string * val_type) list) (body : Ast.expr) =
-  let ctx = make_ctx params in
-  let instrs = compile_expr ctx body in
-  ignore (add_function m ~export (List.map snd params) [I32]
-            !(ctx.extra_locals) instrs)
+(* Letrec: pre-register all bindings as module functions so mutual and
+   self references work, then compile each body and the continuation. *)
+and compile_letrec ctx bindings body =
+  let entries = List.map (fun b ->
+    let param_tys = List.map (fun p ->
+      (p.Ast.param_name, val_type_of_type_expr p.Ast.param_type)
+    ) b.Ast.letrec_params in
+    let ret_ty = val_type_of_type_expr b.Ast.letrec_return_type in
+    let idx = reserve_function ctx.module_ (List.map snd param_tys) [ret_ty] in
+    (b, idx, param_tys)
+  ) bindings in
+  let new_func_map =
+    List.map (fun (b, idx, _) -> (b.Ast.letrec_name, idx)) entries
+    @ ctx.func_map
+  in
+  List.iter (fun (b, idx, param_tys) ->
+    let fn_ctx = make_ctx param_tys new_func_map ctx.module_ ctx.pending in
+    let instrs  = compile_expr fn_ctx b.Ast.letrec_body in
+    ctx.pending := !(ctx.pending) @ [(idx, !(fn_ctx.extra_locals), instrs)]
+  ) entries;
+  compile_expr { ctx with func_map = new_func_map } body
 
 (* ------------------------------------------------------------------ *)
 (* Module emitter                                                       *)
 (* ------------------------------------------------------------------ *)
 
 let emit (prog : Ast.program) : bytes =
-  let m = create () in
-  let main_decl =
-    List.find_opt (fun d -> match d.Ast.decl_desc with
-      | Ast.DeclFn { fn_name = "main"; _ } -> true
-      | _ -> false) prog
+  let m       = create () in
+  let pending = ref [] in
+  (* Collect top-level function declarations whose types we can handle,
+     extracting the fields we need as a plain tuple to avoid inline-record
+     binding restrictions. *)
+  let fn_decls =
+    List.filter_map (fun d ->
+      match d.Ast.decl_desc with
+      | Ast.DeclFn { fn_name; pub; params; return_type = Some ret; decl_body; _ }
+        when List.for_all (fun p -> is_supported_type p.Ast.param_type) params
+          && is_supported_type ret ->
+        Some (fn_name, pub, params, ret, decl_body)
+      | _ -> None
+    ) prog
   in
-  (match main_decl with
-   | Some { Ast.decl_desc = Ast.DeclFn { decl_body; _ }; _ } ->
-     compile_fn m ~export:"main" ~params:[] decl_body
-   | _ ->
-     ignore (add_function m ~export:"main" [] [I32] [] [I32Const 0]));
+  (* Pass 1: pre-register all functions; builds the func_map. *)
+  let fn_entries =
+    List.map (fun (fn_name, pub, params, ret, decl_body) ->
+      let param_tys = List.map (fun p ->
+        (p.Ast.param_name, val_type_of_type_expr p.Ast.param_type)
+      ) params in
+      let ret_ty = val_type_of_type_expr ret in
+      let idx = reserve_function m (List.map snd param_tys) [ret_ty] in
+      if pub || fn_name = "main" then
+        add_export m fn_name (ExportFunc idx);
+      (fn_name, idx, param_tys, decl_body)
+    ) fn_decls
+  in
+  let func_map = List.map (fun (fn_name, idx, _, _) -> (fn_name, idx)) fn_entries in
+  (* Pass 2: compile each function body, accumulating into pending. *)
+  List.iter (fun (_, idx, param_tys, decl_body) ->
+    let ctx    = make_ctx param_tys func_map m pending in
+    let instrs = compile_expr ctx decl_body in
+    pending := !pending @ [(idx, !(ctx.extra_locals), instrs)]
+  ) fn_entries;
+  (* Emit a stub main returning 0 when none was declared. *)
+  if not (List.exists (fun (name, _, _, _) -> name = "main") fn_entries) then begin
+    let idx = reserve_function m [] [I32] in
+    add_export m "main" (ExportFunc idx);
+    pending := !pending @ [(idx, [], [I32Const 0])]
+  end;
+  (* Flush bodies in function-index order so func and code sections align. *)
+  let sorted = List.sort (fun (i, _, _) (j, _, _) -> compare i j) !pending in
+  List.iter (fun (_, locals, instrs) -> add_body m locals instrs) sorted;
   encode m
 
 let emit_stub = emit

--- a/lib/wasm/wasm_encode.ml
+++ b/lib/wasm/wasm_encode.ml
@@ -460,3 +460,17 @@ let add_function m ?(export = "") params results locals instrs =
   let func_idx = add_func m type_idx locals instrs in
   if export <> "" then add_export m export (ExportFunc func_idx);
   func_idx
+
+(** Reserve a function slot (type + func-section entry) without a body.
+    Returns the function index. The caller must call [add_body] exactly once
+    per reserved slot, in index order, before calling [encode]. *)
+let reserve_function m params results =
+  let type_idx = add_type m { params; results } in
+  let func_idx = List.length m.imports + List.length m.funcs in
+  m.funcs <- m.funcs @ [type_idx];
+  func_idx
+
+(** Append a function body.  Must be called once for each slot produced by
+    [reserve_function] (or [add_func]), in the same index order. *)
+let add_body m locals instrs =
+  m.bodies <- m.bodies @ [(locals, instrs)]

--- a/test/test_build_pipeline.ml
+++ b/test/test_build_pipeline.ml
@@ -209,6 +209,45 @@ let src_main_let_arithmetic =
 }|}
 (* a = 7, b = 14, result = 13 *)
 
+(* Issue #35: top-level functions and direct/recursive calls *)
+let src_calls_helper =
+  {|fn double(x: Int) -> Int ! pure {
+  add(x, x)
+}
+
+fn main() -> Int ! pure {
+  double(21)
+}|}
+
+let src_recursive_fact =
+  {|fn fact(n: Int) -> Int ! pure {
+  if eq(n, 0) { 1 } else { mul(n, fact(sub(n, 1))) }
+}
+
+fn main() -> Int ! pure {
+  fact(5)
+}|}
+(* fact(5) = 120 *)
+
+let src_do_block =
+  {|fn main() -> Int ! pure {
+  do {
+    let a = add(3, 4);
+    let b = mul(a, 2);
+    sub(b, 1)
+  }
+}|}
+(* a = 7, b = 14, result = 13 *)
+
+let src_letrec_fact =
+  {|fn main() -> Int ! pure {
+  letrec {
+    fact(n: Int): Int = if eq(n, 0) { 1 } else { mul(n, fact(sub(n, 1))) }
+  } in
+  fact(5)
+}|}
+(* fact(5) = 120 *)
+
 (* ------------------------------------------------------------------ *)
 (* Build tests                                                         *)
 (* ------------------------------------------------------------------ *)
@@ -311,5 +350,9 @@ let () =
     ; ( "codegen",
         [ Alcotest.test_case "add(1,2) = 3"           `Quick (test_main_returns src_main_add_literals 3)
         ; Alcotest.test_case "let+arithmetic = 13"    `Quick (test_main_returns src_main_let_arithmetic 13)
+        ; Alcotest.test_case "double(21) = 42"        `Quick (test_main_returns src_calls_helper 42)
+        ; Alcotest.test_case "fact(5) = 120"          `Quick (test_main_returns src_recursive_fact 120)
+        ; Alcotest.test_case "do block = 13"          `Quick (test_main_returns src_do_block 13)
+        ; Alcotest.test_case "letrec fact(5) = 120"   `Quick (test_main_returns src_letrec_fact 120)
         ] )
     ]


### PR DESCRIPTION
Closes #35

## Summary

- **Two-pass compilation**: all top-level `fn` declarations are pre-registered as WASM functions before any body is compiled, so recursive and forward references resolve correctly via the `call` instruction
- **`wasm_encode.ml`**: added `reserve_function` (register signature without body) and `add_body` (flush body later) to support the two-pass approach
- **`codegen.ml`**: extended `compile_expr` with `If`, `Do`, `Letrec`, and general function-call `App` (emits `call i`); added comparison primitives `eq`/`lt`/`gt`; rewrote `emit` with two-pass logic and pending-body sorting so letrec bodies and top-level bodies land in the correct WASM index order
- **`test_build_pipeline.ml`**: four new execution tests covering a helper call (`double(21)=42`), direct top-level recursion (`fact(5)=120`), do-blocks, and letrec-grouped recursion

## Test plan

- [x] All existing tests continue to pass (backward-compatible: unsupported-type functions are skipped, stub `main` still generated when absent)
- [x] `double(21) = 42` — top-level helper call via `call` instruction
- [x] `fact(5) = 120` — directly recursive top-level function
- [x] `do { let a = …; let b = …; expr }` — sequential do-block emission with `drop`
- [x] `letrec { fact(n: Int): Int = … } in fact(5)` — letrec-grouped recursion lowered to module functions

https://claude.ai/code/session_013oPP7oZFb2u2deRgqqbedb

---
_Generated by [Claude Code](https://claude.ai/code/session_013oPP7oZFb2u2deRgqqbedb)_