### PR TITLE
Linear memory, bump allocator, and boxed-value layout (#37)

### DIFF
--- a/docs/implementation/codegen.md
+++ b/docs/implementation/codegen.md
@@ -101,12 +101,13 @@ I32Add                LocalSet idx        If (bt, then_, else_)
 I32Sub                LocalTee idx        Block (bt, body)
 I32Mul                Return              Loop (bt, body)
 I32Eq                 Drop                Br label
-I32LtS                                    BrIf label
-I32GtS                                    BrTable (labels, default)
+I32LtS                GlobalGet idx       BrIf label
+I32GtS                GlobalSet idx       BrTable (labels, default)
+                      I32Load (al, off)
+                      I32Store (al, off)
 ```
 
-No floating-point instructions, no memory load/store, no SIMD, no
-GC proposal types.
+No floating-point instructions, no SIMD, no GC proposal types.
 
 ### Public functions
 
@@ -158,13 +159,87 @@ indices, and integer immediates throughout the binary format.
 
 - **Instruction set**: only the MVP subset listed above; no `i64`/`f32`/`f64`
   constants as instructions (though globals can hold those values), no
-  memory access, no atomics, no SIMD, no multi-value blocks beyond the
-  `results` array on `func_type`.
+  atomics, no SIMD, no multi-value blocks beyond the `results` array on
+  `func_type`.
 - **Imports**: function imports only (`ImportFunc`); table/memory/global
   imports are not encoded.
 - **Segments**: active segments only (memory 0 for data, table 0 for
   elements); passive segments are not supported.
 - **No Memory64, GC proposal, or exception-handling proposal.**
+
+---
+
+---
+
+## Linear memory and bump allocator (Milestone 2 prerequisite)
+
+### Memory section
+
+Every module emitted by `codegen.ml` includes a single linear memory of
+**one page (65 536 bytes)** with no declared maximum.  The memory is
+exported under the name `"memory"` so host embedders and tests can
+inspect it.
+
+```
+(memory (export "memory") 1)
+```
+
+### `__heap_ptr` global
+
+A mutable `i32` global named `__heap_ptr` (global index 0) is emitted
+before any user-defined globals.  Its initial value is **1024**, leaving
+the first 1 KiB as a reserved static zone (currently unused; reserved
+for future static-data segments).
+
+```
+(global $__heap_ptr (mut i32) (i32.const 1024))
+```
+
+### `__alloc` function
+
+`__alloc` is function index 0 in every module.  Its signature is:
+
+```
+(func $__alloc (export "__alloc") (param $size i32) (result i32)
+  ;; Save old heap_ptr, bump by size, return old value.
+  global.get $__heap_ptr
+  local.tee $saved          ;; local[1]: saved old ptr
+  local.get $size           ;; local[0]: size param
+  i32.add
+  global.set $__heap_ptr
+  local.get $saved)
+```
+
+Calling `__alloc(n)` returns the address of a freshly allocated `n`-byte
+region and advances `__heap_ptr` by `n`.  There is no alignment
+guarantee beyond what the caller requests; callers allocating word-sized
+fields should round `n` up to a multiple of 4 themselves.
+
+No freeing, no GC, no growth beyond one page — out of scope for now.
+
+### Boxed-value layout
+
+ADT constructor values are represented as **tagged heap records**:
+
+```
+offset +0 : i32  tag        (constructor index, 0-based)
+offset +4 : i32  field[0]   (first payload field)
+offset +8 : i32  field[1]   ...
+...
+```
+
+All payload fields are `i32` in v1.  A field holds either:
+
+- A 32-bit integer or boolean value packed directly, or
+- A heap pointer (i32 address) to another boxed value.
+
+**Allocation size** for a constructor with `k` fields is `4 * (1 + k)`
+bytes.  The emitter calls `__alloc(4 * (1 + k))`, then uses
+`i32.store` at `ptr + 0` for the tag and `ptr + 4*i` for field `i`.
+
+**Alignment rule**: every allocation is a multiple of 4 bytes and
+`__heap_ptr` starts at 1024 (also a multiple of 4), so all word
+accesses are naturally aligned.
 
 ---
 

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -171,6 +171,24 @@ and compile_letrec ctx bindings body =
 
 let emit (prog : Ast.program) : bytes =
   let m       = create () in
+  (* Linear memory: one 64 KiB page; no upper bound. *)
+  add_memory m { min = 1; max = None };
+  add_export m "memory" (ExportMem 0);
+  (* Mutable heap pointer; bump-allocator starts above a 1 KiB reserved zone. *)
+  let heap_ptr_idx = add_global m I32 true (GlobI32 1024) in
+  (* __alloc(size: i32) -> i32 — bumps __heap_ptr by size, returns old value.
+     local[0]=size (param), local[1]=saved old ptr (extra). *)
+  let _ = add_function m ~export:"__alloc"
+    [I32] [I32]
+    [{ count = 1; ty = I32 }]
+    [ GlobalGet heap_ptr_idx   (* push old __heap_ptr *)
+    ; LocalTee 1               (* save it; still on stack *)
+    ; LocalGet 0               (* push size *)
+    ; I32Add                   (* old + size *)
+    ; GlobalSet heap_ptr_idx   (* __heap_ptr = old + size *)
+    ; LocalGet 1               (* return old __heap_ptr *)
+    ]
+  in
   let pending = ref [] in
   (* Collect top-level function declarations whose types we can handle,
      extracting the fields we need as a plain tuple to avoid inline-record

--- a/lib/wasm/wasm_encode.ml
+++ b/lib/wasm/wasm_encode.ml
@@ -43,6 +43,10 @@ type instr =
   | BrTable of int list * int  (** targets, default *)
   | Return
   | Drop
+  | GlobalGet of int
+  | GlobalSet of int
+  | I32Load of int * int   (** align, offset *)
+  | I32Store of int * int  (** align, offset *)
 
 (** Run-length encoded local variable group in a function body. *)
 type local_decl = {
@@ -228,6 +232,20 @@ let rec put_instr buf instr =
     put_uleb128 buf default
   | Return -> put_byte buf 0x0F
   | Drop   -> put_byte buf 0x1A
+  | GlobalGet i ->
+    put_byte buf 0x23;
+    put_uleb128 buf i
+  | GlobalSet i ->
+    put_byte buf 0x24;
+    put_uleb128 buf i
+  | I32Load (align, offset) ->
+    put_byte buf 0x28;
+    put_uleb128 buf align;
+    put_uleb128 buf offset
+  | I32Store (align, offset) ->
+    put_byte buf 0x36;
+    put_uleb128 buf align;
+    put_uleb128 buf offset
 
 (* ------------------------------------------------------------------ *)
 (* Section helpers                                                     *)

--- a/test/test_build_pipeline.ml
+++ b/test/test_build_pipeline.ml
@@ -299,6 +299,53 @@ let src_letrec_fact =
 (* fact(5) = 120 *)
 
 (* ------------------------------------------------------------------ *)
+(* Allocator execution helper                                          *)
+(* ------------------------------------------------------------------ *)
+
+(** Instantiate the module at [path] via Node.js, call __alloc twice,
+    write/read through the exported memory, and return the first
+    allocation address. *)
+let run_alloc_check path =
+  if not (Lazy.force has_node) then
+    RunSkip "no node.js runtime available"
+  else
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         WebAssembly.instantiate(buf).then(({instance})=>{\
+           const e=instance.exports;\
+           const ptr=e.__alloc(8);\
+           if(ptr<1024){console.error('ptr too low:'+ptr);process.exit(1);}\
+           const mem=new Uint32Array(e.memory.buffer);\
+           mem[ptr>>2]=0xABCD;\
+           if(mem[ptr>>2]!==0xABCD){console.error('rw mismatch');process.exit(2);}\
+           const ptr2=e.__alloc(4);\
+           if(ptr2!==ptr+8){console.error('bump wrong:'+ptr2);process.exit(3);}\
+           console.log(ptr);\
+         }).catch(e=>{console.error(e.message);process.exit(4);});"
+        (Filename.quote path)
+    in
+    let tmp = Filename.temp_file "axiom_alloc_" ".txt" in
+    let rc =
+      Sys.command
+        (Printf.sprintf "node -e %s >%s 2>/dev/null"
+           (Filename.quote script) (Filename.quote tmp))
+    in
+    let out =
+      let ic = open_in tmp in
+      let s = try input_line ic with End_of_file -> "" in
+      close_in ic;
+      (try Sys.remove tmp with _ -> ());
+      String.trim s
+    in
+    if rc <> 0 then RunFail (Printf.sprintf "node exited %d" rc)
+    else
+      match int_of_string_opt out with
+      | Some n -> Got n
+      | None   -> RunFail (Printf.sprintf "unexpected output: %S" out)
+
+(* ------------------------------------------------------------------ *)
 (* Build tests                                                         *)
 (* ------------------------------------------------------------------ *)
 
@@ -372,6 +419,24 @@ let test_main_returns src expected () =
       | RunFail m -> Alcotest.fail ("execution failed: " ^ m)
       | RunSkip m -> Printf.printf "[SKIP] %s\n%!" m))
 
+(** Check that every compiled module exports __alloc, and that calling
+    it twice with sizes 8 and 4 returns consecutive addresses >= 1024. *)
+let test_allocator_exported src () =
+  with_tmp_file ".axm" (fun s ->
+    with_tmp_file ".wasm" (fun d ->
+      write_file s src;
+      let rc = axiom_build ~src:s ~dst:d in
+      if rc <> 0 then Alcotest.fail "axiom build failed";
+      match validate_wasm d with
+      | Fail msg -> Alcotest.fail msg
+      | Skip msg -> Printf.printf "[SKIP] %s\n%!" msg
+      | Pass ->
+        match run_alloc_check d with
+        | Got n when n >= 1024 -> ()
+        | Got n    -> Alcotest.failf "__alloc returned %d, want >= 1024" n
+        | RunFail m -> Alcotest.fail ("allocator check failed: " ^ m)
+        | RunSkip m -> Printf.printf "[SKIP] %s\n%!" m))
+
 (* ------------------------------------------------------------------ *)
 (* Suite                                                               *)
 (* ------------------------------------------------------------------ *)
@@ -414,5 +479,9 @@ let () =
         ; Alcotest.test_case "gte(5,3) -> 1"          `Quick (test_main_returns src_if_gte 1)
         ; Alcotest.test_case "bool_to_int(true) = 1"  `Quick (test_main_returns src_bool_to_int 1)
         ; Alcotest.test_case "abs(neg(5)) = 5"        `Quick (test_main_returns src_abs 5)
+        ] )
+    ; ( "allocator",
+        [ Alcotest.test_case "__alloc exported (empty)"     `Quick (test_allocator_exported src_empty)
+        ; Alcotest.test_case "__alloc exported (simple fn)" `Quick (test_allocator_exported src_main_add_literals)
         ] )
     ]

--- a/test/test_wasm_encode.ml
+++ b/test/test_wasm_encode.ml
@@ -353,6 +353,74 @@ let test_call_runs () =
     Alcotest.(check string) "quad(3)=12" "12" (String.trim s))
 
 (* ------------------------------------------------------------------ *)
+(* Test 6: globals and memory (bump allocator)                        *)
+(*   (memory 1)                                                        *)
+(*   (global $g (mut i32) (i32.const 1024))                           *)
+(*   (func (export "alloc") (param i32) (result i32)                  *)
+(*     global.get $g  local.tee 1  local.get 0  i32.add               *)
+(*     global.set $g  local.get 1)                                     *)
+(*   (func (export "store_load") (result i32)                          *)
+(*     ;; alloc 4 bytes, store 99, reload and return it               *)
+(*     i32.const 4  call $alloc  local.tee 0                          *)
+(*     i32.const 99  i32.store align=2 offset=0                        *)
+(*     local.get 0  i32.load align=2 offset=0)                         *)
+(* ------------------------------------------------------------------ *)
+
+let build_alloc_module () =
+  let m = create () in
+  add_memory m { min = 1; max = None };
+  add_export m "memory" (ExportMem 0);
+  let g = add_global m I32 true (GlobI32 1024) in
+  let alloc_idx =
+    add_function m ~export:"alloc" [I32] [I32]
+      [{ count = 1; ty = I32 }]
+      [ GlobalGet g; LocalTee 1; LocalGet 0; I32Add; GlobalSet g; LocalGet 1 ]
+  in
+  let _ =
+    add_function m ~export:"store_load" [] [I32]
+      [{ count = 1; ty = I32 }]
+      [ I32Const 4; Call alloc_idx; LocalTee 0
+      ; I32Const 99; I32Store (2, 0)
+      ; LocalGet 0;  I32Load  (2, 0)
+      ]
+  in
+  encode m
+
+let test_alloc_valid () =
+  match node_validate (build_alloc_module ()) with
+  | Ok ()     -> ()
+  | Error msg -> Alcotest.fail ("wasm invalid: " ^ msg)
+
+let test_alloc_runs () =
+  with_tmp_wasm (build_alloc_module ()) (fun path ->
+    let quoted = Filename.quote path in
+    let script =
+      Printf.sprintf
+        "const fs=require('fs');\
+         const buf=fs.readFileSync(%s);\
+         WebAssembly.instantiate(buf).then(({instance})=>{\
+           const e=instance.exports;\
+           const ptr=e.alloc(8);\
+           if(ptr<1024){process.exit(1);}\
+           const mem=new Uint32Array(e.memory.buffer);\
+           mem[ptr>>2]=0xCAFE;\
+           if(mem[ptr>>2]!==0xCAFE){process.exit(2);}\
+           const ptr2=e.alloc(4);\
+           if(ptr2!==ptr+8){process.exit(3);}\
+           console.log(e.store_load());\
+         }).catch(e=>{console.error(e.message);process.exit(4);});"
+        quoted
+    in
+    let tmp = Filename.temp_file "axiom_wasm_alloc_" ".txt" in
+    ignore (Sys.command (Printf.sprintf "node -e %s >%s 2>/dev/null"
+                           (Filename.quote script) (Filename.quote tmp)));
+    let ic = open_in tmp in
+    let s = (try input_line ic with End_of_file -> "") in
+    close_in ic;
+    (try Sys.remove tmp with _ -> ());
+    Alcotest.(check string) "store_load()=99" "99" (String.trim s))
+
+(* ------------------------------------------------------------------ *)
 (* Test suite registration                                             *)
 (* ------------------------------------------------------------------ *)
 
@@ -384,5 +452,9 @@ let () =
     ; ( "call",
         [ Alcotest.test_case "wasm-validate" `Quick test_call_valid
         ; Alcotest.test_case "quad(3)=12"    `Quick test_call_runs
+        ] )
+    ; ( "globals_and_memory",
+        [ Alcotest.test_case "wasm-validate"   `Quick test_alloc_valid
+        ; Alcotest.test_case "alloc/store/load" `Quick test_alloc_runs
         ] )
     ]


### PR DESCRIPTION
Closes #37

## Summary

- **`lib/wasm/wasm_encode.ml`**: Add `GlobalGet`, `GlobalSet`, `I32Load`, and `I32Store` instructions to the encoder's instruction ADT and `put_instr` switch.
- **`lib/codegen.ml`**: Every emitted module now includes a one-page linear memory (exported as `"memory"`), a mutable `__heap_ptr` global (i32, initial value 1024), and a `__alloc(size: i32) -> i32` function (exported as `"__alloc"`, function index 0) that bumps the heap pointer and returns the old value.
- **`docs/implementation/codegen.md`**: New sections document the memory section, `__heap_ptr` global, `__alloc` semantics, and the boxed-value record layout (`[i32 tag][i32 field0][i32 field1]…`) used by ADT constructors.

## Test plan

- [ ] `dune test` passes with no failures
- `test/test_wasm_encode.ml` — new `globals_and_memory` group: validates a hand-built module with a global, `alloc`, and `store_load`, then runs it via Node.js and checks `store_load()` returns 99
- `test/test_build_pipeline.ml` — new `allocator` group: compiles two Axiom programs, validates the WASM, instantiates via Node.js, calls `__alloc(8)` + `__alloc(4)`, writes/reads through `memory`, and checks the returned addresses are ≥ 1024 and consecutive

https://claude.ai/code/session_01PjhGg3hviqie9dpg7gfAgJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjhGg3hviqie9dpg7gfAgJ)_