### PR TITLE
Implement decision-tree pattern compilation (#39)

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -90,44 +90,71 @@ let rec compile_ctor ctx tag args =
     ) args)
   @ [LocalGet ptr_local]
 
-(* Chained if/else dispatch for match arms. scrut_local holds the ADT pointer;
-   tag_local holds the already-loaded tag. *)
-and compile_match ctx scrut_local tag_local arms =
+(* Compile a single pattern against scrut_local.
+   on_match ctx' = instructions to emit when the pattern matches (ctx' has new bindings).
+   on_fail       = instruction list to emit when the pattern does not match. *)
+and compile_pat ctx scrut_local pat on_match on_fail =
+  match pat.Ast.pat_desc with
+  | Ast.PWild ->
+    on_match ctx
+
+  | Ast.PVar x ->
+    on_match { ctx with env = (x, scrut_local) :: ctx.env }
+
+  | Ast.PLitInt n ->
+    [LocalGet scrut_local; I32Const (Int64.to_int n); I32Eq;
+     If (ValType I32, on_match ctx, Some on_fail)]
+
+  | Ast.PLitTrue ->
+    [LocalGet scrut_local; I32Const 1; I32Eq;
+     If (ValType I32, on_match ctx, Some on_fail)]
+
+  | Ast.PLitFalse ->
+    [LocalGet scrut_local; I32Const 0; I32Eq;
+     If (ValType I32, on_match ctx, Some on_fail)]
+
+  | Ast.PCtor (ctor_name, sub_pats) ->
+    let (tag, _) = List.assoc ctor_name ctx.ctor_map in
+    (* Allocate a local for each constructor field up front. *)
+    let field_locals = List.mapi (fun i _ -> (i, alloc_local ctx)) sub_pats in
+    (* Load each field from heap slot i+1 into its local. *)
+    let load_fields = List.concat_map (fun (i, li) ->
+      [LocalGet scrut_local; I32Load (2, (i + 1) * 4); LocalSet li]
+    ) field_locals in
+    (* Chain sub-pattern checks for each field. *)
+    let pairs = List.map2 (fun (_, li) p -> (li, p)) field_locals sub_pats in
+    let inner = chain_pats ctx pairs on_match on_fail in
+    [LocalGet scrut_local; I32Load (2, 0); I32Const tag; I32Eq;
+     If (ValType I32, load_fields @ inner, Some on_fail)]
+
+  | Ast.POr (p1, p2) ->
+    (* Try p1; on failure try p2. *)
+    let try_p2 = compile_pat ctx scrut_local p2 on_match on_fail in
+    compile_pat ctx scrut_local p1 on_match try_p2
+
+  | other ->
+    failwith (Format.asprintf "Codegen: unsupported pattern: %a"
+                Ast.pp_pattern_desc other)
+
+(* Chain a list of (field_local, sub_pattern) pairs for constructor field checks. *)
+and chain_pats ctx pairs on_match on_fail =
+  match pairs with
+  | [] -> on_match ctx
+  | (li, pat) :: rest ->
+    compile_pat ctx li pat
+      (fun ctx' -> chain_pats ctx' rest on_match on_fail)
+      on_fail
+
+(* Decision-tree dispatch for match arms. scrut_local holds the scrutinee value. *)
+and compile_match ctx scrut_local arms =
   match arms with
   | [] ->
     [I32Const 0]  (* exhaustive matches should not reach here *)
-
-  | { Ast.pattern = { pat_desc = Ast.PWild; _ }; arm_body } :: _ ->
-    compile_expr ctx arm_body
-
-  | { Ast.pattern = { pat_desc = Ast.PVar x; _ }; arm_body } :: _ ->
-    compile_expr { ctx with env = (x, scrut_local) :: ctx.env } arm_body
-
-  | { Ast.pattern = { pat_desc = Ast.PCtor (ctor_name, sub_pats); _ }; arm_body } :: rest ->
-    let (tag, _) = List.assoc ctor_name ctx.ctor_map in
-    (* Bind each PVar sub-pattern to a fresh local loaded from the ADT fields. *)
-    let field_bindings = List.filter_map (fun (i, p) ->
-      match p.Ast.pat_desc with
-      | Ast.PVar x ->
-        let li = alloc_local ctx in
-        Some (x, li, i + 1)   (* field slot i+1 in the heap word *)
-      | Ast.PWild -> None
-      | _ -> failwith "Codegen: nested patterns not supported"
-    ) (List.mapi (fun i p -> (i, p)) sub_pats) in
-    let field_setup = List.concat_map (fun (_, li, slot) ->
-      [LocalGet scrut_local; I32Load (2, slot * 4); LocalSet li]
-    ) field_bindings in
-    let new_env =
-      List.map (fun (x, li, _) -> (x, li)) field_bindings @ ctx.env
-    in
-    [LocalGet tag_local; I32Const tag; I32Eq;
-     If (ValType I32,
-         field_setup @ compile_expr { ctx with env = new_env } arm_body,
-         Some (compile_match ctx scrut_local tag_local rest))]
-
-  | { Ast.pattern = { pat_desc; _ }; _ } :: _ ->
-    failwith (Format.asprintf "Codegen: unsupported match pattern: %a"
-                Ast.pp_pattern_desc pat_desc)
+  | arm :: rest ->
+    let on_fail = compile_match ctx scrut_local rest in
+    compile_pat ctx scrut_local arm.Ast.pattern
+      (fun ctx' -> compile_expr ctx' arm.Ast.arm_body)
+      on_fail
 
 and compile_expr ctx expr =
   match expr.Ast.desc with
@@ -186,11 +213,9 @@ and compile_expr ctx expr =
 
   | Ast.Match { scrutinee; arms } ->
     let scrut_local = alloc_local ctx in
-    let tag_local   = alloc_local ctx in
     compile_expr ctx scrutinee
-    @ [LocalSet scrut_local;
-       LocalGet scrut_local; I32Load (2, 0); LocalSet tag_local]
-    @ compile_match ctx scrut_local tag_local arms
+    @ [LocalSet scrut_local]
+    @ compile_match ctx scrut_local arms
 
   | Ast.Do stmts ->
     compile_do ctx stmts

--- a/test/test_build_pipeline.ml
+++ b/test/test_build_pipeline.ml
@@ -407,6 +407,74 @@ let run_alloc_check path =
       | None   -> RunFail (Printf.sprintf "unexpected output: %S" out)
 
 (* ------------------------------------------------------------------ *)
+(* Issue #39: decision-tree pattern matching fixtures                  *)
+(* ------------------------------------------------------------------ *)
+
+(* Recursive ADT: length of a linked list *)
+let src_list_length =
+  {|type List = | Nil | Cons(Int, List)
+
+fn length(l: List) -> Int ! pure {
+  match l with {
+    | Nil => 0
+    | Cons(_, t) => add(1, length(t))
+  }
+}
+
+fn main() -> Int ! pure {
+  length(Cons(1, Cons(2, Cons(3, Nil))))
+}|}
+(* length([1,2,3]) = 3 *)
+
+(* Or-patterns: two constructors share one arm *)
+let src_or_pattern =
+  {|type Color = | Red | Green | Blue
+
+fn is_warm(c: Color) -> Int ! pure {
+  match c with {
+    | Red | Green => 1
+    | Blue => 0
+  }
+}
+
+fn main() -> Int ! pure {
+  is_warm(Green)
+}|}
+(* Green is warm => 1 *)
+
+(* Nested constructor patterns: extract the head of the tail *)
+let src_nested_pattern =
+  {|type List = | Nil | Cons(Int, List)
+
+fn head_of_tail(l: List) -> Int ! pure {
+  match l with {
+    | Cons(_, Cons(h, _)) => h
+    | _ => 0
+  }
+}
+
+fn main() -> Int ! pure {
+  head_of_tail(Cons(1, Cons(42, Cons(3, Nil))))
+}|}
+(* second element = 42 *)
+
+(* 3-level nested constructor pattern *)
+let src_triple_nested =
+  {|type List = | Nil | Cons(Int, List)
+
+fn third(l: List) -> Int ! pure {
+  match l with {
+    | Cons(_, Cons(_, Cons(h, _))) => h
+    | _ => 0
+  }
+}
+
+fn main() -> Int ! pure {
+  third(Cons(1, Cons(2, Cons(99, Nil))))
+}|}
+(* third element = 99 *)
+
+(* ------------------------------------------------------------------ *)
 (* Build tests                                                         *)
 (* ------------------------------------------------------------------ *)
 
@@ -554,5 +622,19 @@ let () =
         ; Alcotest.test_case "get_x(Point(42,7)) = 42"      `Quick (test_main_returns src_point_get_x 42)
         ; Alcotest.test_case "get_y(Point(3,99)) = 99"      `Quick (test_main_returns src_point_get_y 99)
         ; Alcotest.test_case "wildcard: is_circle(Square)=0" `Quick (test_main_returns src_wildcard_match 0)
+        ] )
+    ; ( "pattern_matching",
+        [ Alcotest.test_case "build: list length"           `Quick (test_build_produces_file src_list_length)
+        ; Alcotest.test_case "validate: list length"        `Quick (test_validates src_list_length)
+        ; Alcotest.test_case "length([1,2,3]) = 3"          `Quick (test_main_returns src_list_length 3)
+        ; Alcotest.test_case "build: or-pattern"            `Quick (test_build_produces_file src_or_pattern)
+        ; Alcotest.test_case "validate: or-pattern"         `Quick (test_validates src_or_pattern)
+        ; Alcotest.test_case "is_warm(Green) = 1"           `Quick (test_main_returns src_or_pattern 1)
+        ; Alcotest.test_case "build: nested pattern"        `Quick (test_build_produces_file src_nested_pattern)
+        ; Alcotest.test_case "validate: nested pattern"     `Quick (test_validates src_nested_pattern)
+        ; Alcotest.test_case "head_of_tail([1,42,3]) = 42" `Quick (test_main_returns src_nested_pattern 42)
+        ; Alcotest.test_case "build: triple-nested pattern" `Quick (test_build_produces_file src_triple_nested)
+        ; Alcotest.test_case "validate: triple-nested"      `Quick (test_validates src_triple_nested)
+        ; Alcotest.test_case "third([1,2,99]) = 99"         `Quick (test_main_returns src_triple_nested 99)
         ] )
     ]


### PR DESCRIPTION
## Summary

- Replace the flat pattern dispatcher in `codegen.ml` with a recursive `compile_pat` / `chain_pats` design using continuation-passing style
- Nested constructor patterns at arbitrary depth (e.g. `Cons(_, Cons(h, _))`) now compile and execute correctly
- Or-patterns (`| A | B => body`) compile via sequential fallthrough — each alternative is tried in order, reusing the same body
- Recursive ADTs (`List`, `Option`) work end-to-end; the existing i32-pointer heap layout already accommodates recursive fields

## How it works

`compile_pat ctx scrut_local pat on_match on_fail` is the core recursive function:
- `PWild` / `PVar` — bind immediately and call `on_match`
- `PCtor` — check the tag, load all fields into locals, then call `chain_pats` to recursively match each sub-pattern
- `POr(p1, p2)` — compile p1 with `on_fail = compile p2`, so if p1's tag or sub-patterns fail, p2 is tried automatically
- `PLitInt` / `PLitTrue` / `PLitFalse` — equality check with if/else

`compile_match` becomes a simple fold: the last arm's `on_fail` is `[I32Const 0]` (unreachable in exhaustive matches), and each arm wraps the next as its `on_fail`.

## Test plan

- [x] Existing 35 pipeline tests continue to pass unchanged
- [x] `length([1,2,3]) = 3` — recursive `List` ADT with `Cons`/`Nil`
- [x] `is_warm(Green) = 1` — or-pattern `| Red | Green => 1`
- [x] `head_of_tail([1,42,3]) = 42` — 2-level nested constructor pattern
- [x] `third([1,2,99]) = 99` — 3-level nested constructor pattern
- [x] All four new programs pass `wasm-validate` and produce correct results under wasmtime/node

Closes #39

https://claude.ai/code/session_01DYQaFLihyXHqEJuUdocNgs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYQaFLihyXHqEJuUdocNgs)_