### PR TITLE
Effect evidence-passing elaboration pass (issue #40)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -50,6 +50,7 @@ let () =
    with Failure msg ->
      Printf.eprintf "axiom build: type error: %s\n" msg;
      exit 1);
+  let _elaborated = Axiom_lib.Elaboration.elaborate_program prog in
   let wasm_bytes = Axiom_lib.Codegen.emit prog in
   (try
      let oc = open_out_bin !output_file in

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name axiom_lib)
- (modules lexer ast parser printer typechecker node_hash node_tag node_encoding node_decoding node_store codegen)
+ (modules lexer ast parser printer typechecker elaboration node_hash node_tag node_encoding node_decoding node_store codegen)
  (libraries unix wasm_encode)
  (foreign_stubs
   (language c)

--- a/lib/elaboration.ml
+++ b/lib/elaboration.ml
@@ -1,0 +1,568 @@
+(** Effect evidence-passing elaboration pass (§9.2.1).
+
+    Transforms a type-checked [Ast.program] into an elaborated IR where:
+    - Every function whose effect annotation admits effects gets explicit
+      evidence parameters — one per named effect, in declaration order.
+    - Every call to a function with known effects gets the matching evidence
+      values threaded in as leading arguments.
+    - [Perform] nodes are annotated with the name of the in-scope evidence
+      variable for that effect, ready for later codegen.
+    - [Handle] nodes are preserved; the handled expression sees evidence for
+      each handled effect; handler bodies are elaborated under the outer
+      ambient (handler side-effects flow to the enclosing context).
+    - Pure functions are left structurally identical — no evidence params,
+      no extra arguments.
+
+    Letrec bindings carry no effect annotation in the surface AST; they are
+    treated as pure for the purposes of evidence threading.  Full support
+    for effectful letrec requires a future AST extension.
+*)
+
+open Ast
+
+(* ------------------------------------------------------------------ *)
+(* Evidence parameters                                                  *)
+(* ------------------------------------------------------------------ *)
+
+(** Canonical evidence-variable name for a named effect. *)
+let ev_var_name eff_name = Printf.sprintf "__ev_%s" eff_name
+
+(** An evidence parameter: a named binding for one effect's dictionary. *)
+type evidence_param = {
+  ev_name   : string;   (** e.g. "__ev_Console" *)
+  ev_effect : string;   (** e.g. "Console" *)
+}
+
+let make_ev_param eff_name =
+  { ev_name = ev_var_name eff_name; ev_effect = eff_name }
+
+(* ------------------------------------------------------------------ *)
+(* Elaborated IR                                                        *)
+(* ------------------------------------------------------------------ *)
+
+type eexpr = {
+  edesc : eexpr_desc;
+}
+
+and eexpr_desc =
+  | EVar          of string
+  | EIntLit       of int64
+  | EFloatLit     of float
+  | EStringLit    of string
+  | EBoolLit      of bool
+  | EUnitLit
+  | ELet          of elet_binding
+  | EApp          of eexpr * eexpr list
+  | EFn           of efn_data
+  | EMatch        of ematch_data
+  | EIf           of eif_data
+  | EDo           of edo_stmt list
+  | ELetrec       of eletrec_binding list * eexpr
+  | ERecord       of (string * eexpr) list
+  | ERecordUpdate of eexpr * (string * eexpr) list
+  | EProject      of eexpr * string
+  | EPerform      of eperform_data
+  | EHandle       of ehandle_data
+
+(** A function literal after elaboration.
+    [ev_params] is empty for pure functions (identity transformation). *)
+and efn_data = {
+  ev_params   : evidence_param list;
+  params      : param list;
+  return_type : type_expr option;
+  effects     : effect_set option;
+  fn_body     : eexpr;
+}
+
+and elet_binding = {
+  pat   : pattern;
+  value : eexpr;
+  body  : eexpr;
+}
+
+and ematch_data = {
+  scrutinee : eexpr;
+  arms      : ematch_arm list;
+}
+
+and ematch_arm = {
+  pattern  : pattern;
+  arm_body : eexpr;
+}
+
+and eif_data = {
+  cond  : eexpr;
+  then_ : eexpr;
+  else_ : eexpr;
+}
+
+and edo_stmt =
+  | EStmtLet  of { pat : pattern; value : eexpr }
+  | EStmtExpr of eexpr
+
+and eletrec_binding = {
+  letrec_name        : string;
+  letrec_ev_params   : evidence_param list;
+  letrec_params      : param list;
+  letrec_return_type : type_expr;
+  letrec_body        : eexpr;
+}
+
+(** A [perform] node annotated with the evidence variable in scope.
+    [ev_var] is the name of the evidence dictionary for [effect_name]. *)
+and eperform_data = {
+  effect_name : string;
+  op_name     : string;
+  args        : eexpr list;
+  ev_var      : string;
+}
+
+(** A [handle] node with per-handler evidence bindings.
+    [ev_param] is the evidence parameter created for each handled effect;
+    [handled] is elaborated under an extended ambient that includes those
+    evidence bindings; handler bodies are elaborated under the outer ambient. *)
+and ehandle_data = {
+  handled  : eexpr;
+  handlers : eeffect_handler list;
+}
+
+and eeffect_handler = {
+  effect_handler : string;
+  ev_param       : evidence_param;
+  op_handlers    : eop_handler list;
+  return_handler : ereturn_handler option;
+}
+
+and eop_handler = {
+  op_handler_name   : string;
+  op_handler_params : string list;
+  op_handler_body   : eexpr;
+}
+
+and ereturn_handler = {
+  return_var  : string;
+  return_body : eexpr;
+}
+
+(** Data for an elaborated top-level function declaration. *)
+type edecl_fn = {
+  pub         : bool;
+  fn_name     : string;
+  type_params : string list;
+  ev_params   : evidence_param list;
+  params      : param list;
+  return_type : type_expr option;
+  effects     : effect_set option;
+  decl_body   : eexpr;
+}
+
+(** Top-level declaration after elaboration.
+    Non-function declarations are passed through unchanged via [EDeclPassthrough]. *)
+type edecl = {
+  edecl_desc : edecl_desc;
+}
+
+and edecl_desc =
+  | EDeclFn     of edecl_fn
+  | EDeclModule of { pub : bool; module_name : string; body : edecl list }
+  | EDeclPassthrough of decl_desc
+
+type eprogram = edecl list
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let eexpr desc = { edesc = desc }
+
+(** Extract the flat list of effect names from a surface effect annotation.
+    [TyName "Console"] → ["Console"];  [TyApp("State",_)] → ["State"]. *)
+let effects_of_set = function
+  | None -> []
+  | Some Pure -> []
+  | Some (Effects (effs, _)) ->
+    List.filter_map (function
+      | TyName n     -> Some n
+      | TyApp (n, _) -> Some n
+      | _            -> None) effs
+
+(* ------------------------------------------------------------------ *)
+(* Elaboration context                                                  *)
+(* ------------------------------------------------------------------ *)
+
+(** Maps a function/variable name → the list of effects it requires. *)
+type fn_env = (string * string list) list
+
+(** Maps an effect name → the evidence-variable name currently in scope. *)
+type ev_env = (string * string) list
+
+(** If [pat] binds a single name to a [Fn] literal, record that name's
+    effects so call sites can thread evidence. *)
+let fn_env_extend_let fn_env pat value =
+  match pat.pat_desc, value.desc with
+  | PVar name, Fn { effects; _ } ->
+    (name, effects_of_set effects) :: fn_env
+  | _ -> fn_env
+
+(** Best-effort: extract the effects the callee expression requires.
+    Handles direct named references and immediate lambda applications;
+    returns [[]] for arbitrary higher-order expressions. *)
+let effects_of_callee fn_env (e : Ast.expr) =
+  match e.desc with
+  | Var name ->
+    (match List.assoc_opt name fn_env with Some es -> es | None -> [])
+  | Fn { effects; _ } -> effects_of_set effects
+  | _ -> []
+
+(* ------------------------------------------------------------------ *)
+(* Main elaboration                                                     *)
+(* ------------------------------------------------------------------ *)
+
+let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env) (e : Ast.expr) : eexpr =
+  match e.desc with
+  | Var x       -> eexpr (EVar x)
+  | IntLit n    -> eexpr (EIntLit n)
+  | FloatLit f  -> eexpr (EFloatLit f)
+  | StringLit s -> eexpr (EStringLit s)
+  | BoolLit b   -> eexpr (EBoolLit b)
+  | UnitLit     -> eexpr EUnitLit
+
+  | Let { pat; value; body } ->
+    let fn_env' = fn_env_extend_let fn_env pat value in
+    eexpr (ELet {
+      pat;
+      value = elaborate_expr fn_env  ev_env value;
+      body  = elaborate_expr fn_env' ev_env body;
+    })
+
+  | App (callee, args) ->
+    let ecallee = elaborate_expr fn_env ev_env callee in
+    let eargs   = List.map (elaborate_expr fn_env ev_env) args in
+    let callee_effs = effects_of_callee fn_env callee in
+    let ev_args = List.filter_map (fun eff ->
+        match List.assoc_opt eff ev_env with
+        | Some v -> Some (eexpr (EVar v))
+        | None   -> None
+      ) callee_effs in
+    eexpr (EApp (ecallee, ev_args @ eargs))
+
+  | Fn { params; return_type; effects; fn_body } ->
+    let eff_names = effects_of_set effects in
+    let ev_params = List.map make_ev_param eff_names in
+    let ev_env' = List.fold_left
+        (fun acc ep -> (ep.ev_effect, ep.ev_name) :: acc)
+        ev_env ev_params in
+    eexpr (EFn {
+      ev_params;
+      params;
+      return_type;
+      effects;
+      fn_body = elaborate_expr fn_env ev_env' fn_body;
+    })
+
+  | Perform { effect_name; op_name; args } ->
+    let eargs = List.map (elaborate_expr fn_env ev_env) args in
+    let ev_var =
+      match List.assoc_opt effect_name ev_env with
+      | Some v -> v
+      | None   ->
+        failwith (Printf.sprintf
+                    "Elaboration: no evidence in scope for effect '%s' \
+                     at 'perform %s.%s'"
+                    effect_name effect_name op_name)
+    in
+    eexpr (EPerform { effect_name; op_name; args = eargs; ev_var })
+
+  | Handle { handled; handlers } ->
+    (* Op/return-handler bodies run in the outer ambient (ev_env unchanged). *)
+    let ehandlers = List.map (fun (h : Ast.effect_handler) ->
+        let ev_param = make_ev_param h.effect_handler in
+        let eop_handlers = List.map (fun (oh : Ast.op_handler) ->
+            { op_handler_name   = oh.op_handler_name;
+              op_handler_params = oh.op_handler_params;
+              op_handler_body   = elaborate_expr fn_env ev_env oh.op_handler_body;
+            }
+          ) h.op_handlers in
+        let ereturn = Option.map (fun (rh : Ast.return_handler) ->
+            { return_var  = rh.return_var;
+              return_body = elaborate_expr fn_env ev_env rh.return_body;
+            }
+          ) h.return_handler in
+        { effect_handler = h.effect_handler;
+          ev_param;
+          op_handlers    = eop_handlers;
+          return_handler = ereturn;
+        }
+      ) handlers in
+    (* The handled expression sees evidence for each handled effect. *)
+    let ev_env' = List.fold_left (fun acc (h : Ast.effect_handler) ->
+        (h.effect_handler, ev_var_name h.effect_handler) :: acc
+      ) ev_env handlers in
+    eexpr (EHandle {
+      handled  = elaborate_expr fn_env ev_env' handled;
+      handlers = ehandlers;
+    })
+
+  | Match { scrutinee; arms } ->
+    eexpr (EMatch {
+      scrutinee = elaborate_expr fn_env ev_env scrutinee;
+      arms = List.map (fun (a : Ast.match_arm) ->
+          { pattern  = a.pattern;
+            arm_body = elaborate_expr fn_env ev_env a.arm_body;
+          }) arms;
+    })
+
+  | If { cond; then_; else_ } ->
+    eexpr (EIf {
+      cond  = elaborate_expr fn_env ev_env cond;
+      then_ = elaborate_expr fn_env ev_env then_;
+      else_ = elaborate_expr fn_env ev_env else_;
+    })
+
+  | Do stmts ->
+    let rec go fn_env stmts =
+      match stmts with
+      | [] -> []
+      | StmtLet { pat; value } :: rest ->
+        let fn_env' = fn_env_extend_let fn_env pat value in
+        EStmtLet { pat; value = elaborate_expr fn_env ev_env value }
+        :: go fn_env' rest
+      | StmtExpr e :: rest ->
+        EStmtExpr (elaborate_expr fn_env ev_env e) :: go fn_env rest
+    in
+    eexpr (EDo (go fn_env stmts))
+
+  | Letrec (bindings, body) ->
+    (* Letrec bindings have no effect annotation in the surface AST; they
+       are treated as pure.  A future AST extension could carry effects. *)
+    let fn_env' = List.fold_left
+        (fun acc (b : Ast.letrec_binding) -> (b.letrec_name, []) :: acc)
+        fn_env bindings in
+    let ebindings = List.map (fun (b : Ast.letrec_binding) ->
+        { letrec_name        = b.letrec_name;
+          letrec_ev_params   = [];
+          letrec_params      = b.letrec_params;
+          letrec_return_type = b.letrec_return_type;
+          letrec_body        = elaborate_expr fn_env' ev_env b.letrec_body;
+        }
+      ) bindings in
+    eexpr (ELetrec (ebindings, elaborate_expr fn_env' ev_env body))
+
+  | Record fields ->
+    eexpr (ERecord (List.map (fun (n, v) ->
+        (n, elaborate_expr fn_env ev_env v)) fields))
+
+  | RecordUpdate (e, fields) ->
+    eexpr (ERecordUpdate (
+      elaborate_expr fn_env ev_env e,
+      List.map (fun (n, v) -> (n, elaborate_expr fn_env ev_env v)) fields
+    ))
+
+  | Project (e, field) ->
+    eexpr (EProject (elaborate_expr fn_env ev_env e, field))
+
+(** Build a fn_env from a list of top-level (or module-level) declarations. *)
+let fn_env_of_decls decls =
+  List.filter_map (fun (d : Ast.decl) ->
+    match d.decl_desc with
+    | DeclFn { fn_name; effects; _ } ->
+      Some (fn_name, effects_of_set effects)
+    | _ -> None
+  ) decls
+
+let rec elaborate_decl (fn_env : fn_env) (d : Ast.decl) : edecl =
+  match d.decl_desc with
+  | DeclFn { pub; fn_name; type_params; params; return_type; effects; decl_body } ->
+    let eff_names = effects_of_set effects in
+    let ev_params = List.map make_ev_param eff_names in
+    let ev_env    = List.map (fun ep -> (ep.ev_effect, ep.ev_name)) ev_params in
+    { edecl_desc = EDeclFn {
+        pub; fn_name; type_params; ev_params; params; return_type; effects;
+        decl_body = elaborate_expr fn_env ev_env decl_body;
+      }
+    }
+  | DeclModule { pub; module_name; body } ->
+    let fn_env' = fn_env_of_decls body in
+    { edecl_desc = EDeclModule {
+        pub; module_name;
+        body = List.map (elaborate_decl fn_env') body;
+      }
+    }
+  | other ->
+    { edecl_desc = EDeclPassthrough other }
+
+let elaborate_program (prog : Ast.program) : eprogram =
+  let fn_env = fn_env_of_decls prog in
+  List.map (elaborate_decl fn_env) prog
+
+(* ------------------------------------------------------------------ *)
+(* Pretty-printer (for dump / round-trip tests)                        *)
+(* ------------------------------------------------------------------ *)
+
+let pp_ev_params fmt = function
+  | [] -> ()
+  | evps ->
+    Format.pp_print_string fmt "[";
+    Format.pp_print_list
+      ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+      (fun f ep -> Format.pp_print_string f ep.ev_name)
+      fmt evps;
+    Format.pp_print_string fmt "]"
+
+let rec pp_eexpr fmt e =
+  match e.edesc with
+  | EVar x       -> Format.pp_print_string fmt x
+  | EIntLit n    -> Format.fprintf fmt "%Ld" n
+  | EFloatLit f  -> Format.fprintf fmt "%g" f
+  | EStringLit s -> Format.fprintf fmt "%S" s
+  | EBoolLit b   -> Format.pp_print_bool fmt b
+  | EUnitLit     -> Format.pp_print_string fmt "()"
+
+  | ELet { pat; value; body } ->
+    Format.fprintf fmt "let %a = %a in %a"
+      pp_pattern pat pp_eexpr value pp_eexpr body
+
+  | EApp (f, args) ->
+    Format.fprintf fmt "%a(%a)"
+      pp_eexpr f
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+         pp_eexpr) args
+
+  | EFn { ev_params; params; fn_body; _ } ->
+    Format.fprintf fmt "fn %a(%a) { %a }"
+      pp_ev_params ev_params
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+         (fun f p -> Format.pp_print_string f p.param_name))
+      params
+      pp_eexpr fn_body
+
+  | EPerform { effect_name; op_name; args; ev_var } ->
+    Format.fprintf fmt "perform[%s] %s.%s(%a)"
+      ev_var effect_name op_name
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+         pp_eexpr) args
+
+  | EHandle { handled; handlers } ->
+    Format.fprintf fmt "handle %a with { %a }"
+      pp_eexpr handled
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f "; ")
+         pp_eeffect_handler) handlers
+
+  | EMatch { scrutinee; arms } ->
+    Format.fprintf fmt "match %a with { %a }"
+      pp_eexpr scrutinee
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f " | ")
+         pp_ematch_arm) arms
+
+  | EIf { cond; then_; else_ } ->
+    Format.fprintf fmt "if %a { %a } else { %a }"
+      pp_eexpr cond pp_eexpr then_ pp_eexpr else_
+
+  | EDo stmts ->
+    Format.fprintf fmt "do { %a }"
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f "; ")
+         pp_edo_stmt) stmts
+
+  | ELetrec (bindings, body) ->
+    Format.fprintf fmt "letrec %a in %a"
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f " and ")
+         pp_eletrec_binding) bindings
+      pp_eexpr body
+
+  | ERecord fields ->
+    Format.fprintf fmt "{ %a }"
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+         (fun f (n, v) -> Format.fprintf f "%s = %a" n pp_eexpr v)) fields
+
+  | ERecordUpdate (e, fields) ->
+    Format.fprintf fmt "{ %a with %a }"
+      pp_eexpr e
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+         (fun f (n, v) -> Format.fprintf f "%s = %a" n pp_eexpr v)) fields
+
+  | EProject (e, field) ->
+    Format.fprintf fmt "%a.%s" pp_eexpr e field
+
+and pp_eeffect_handler fmt h =
+  Format.fprintf fmt "%s[ev:%s] { %a%a }"
+    h.effect_handler h.ev_param.ev_name
+    (Format.pp_print_list
+       ~pp_sep:(fun f () -> Format.pp_print_string f " ")
+       pp_eop_handler) h.op_handlers
+    (fun f -> function
+       | None    -> ()
+       | Some rh ->
+         Format.fprintf f " return %s => %a" rh.return_var pp_eexpr rh.return_body)
+    h.return_handler
+
+and pp_eop_handler fmt oh =
+  Format.fprintf fmt "%s(%a) => %a"
+    oh.op_handler_name
+    (Format.pp_print_list
+       ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+       Format.pp_print_string) oh.op_handler_params
+    pp_eexpr oh.op_handler_body
+
+and pp_ematch_arm fmt a =
+  Format.fprintf fmt "%a => %a" pp_pattern a.pattern pp_eexpr a.arm_body
+
+and pp_edo_stmt fmt = function
+  | EStmtLet { pat; value } ->
+    Format.fprintf fmt "let %a = %a" pp_pattern pat pp_eexpr value
+  | EStmtExpr e -> pp_eexpr fmt e
+
+and pp_eletrec_binding fmt b =
+  Format.fprintf fmt "%s%a(%a) = %a"
+    b.letrec_name
+    pp_ev_params b.letrec_ev_params
+    (Format.pp_print_list
+       ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+       (fun f p -> Format.pp_print_string f p.param_name))
+    b.letrec_params
+    pp_eexpr b.letrec_body
+
+let rec pp_edecl fmt d =
+  match d.edecl_desc with
+  | EDeclFn { fn_name; ev_params; params; decl_body; _ } ->
+    Format.fprintf fmt "fn %s%a(%a) { %a }"
+      fn_name
+      pp_ev_params ev_params
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
+         (fun f p -> Format.pp_print_string f p.param_name))
+      params
+      pp_eexpr decl_body
+  | EDeclModule { module_name; body; _ } ->
+    Format.fprintf fmt "module %s { %a }"
+      module_name
+      (Format.pp_print_list
+         ~pp_sep:(fun f () -> Format.pp_print_string f "; ")
+         pp_edecl) body
+  | EDeclPassthrough (DeclEffect { effect_name; _ }) ->
+    Format.fprintf fmt "effect %s" effect_name
+  | EDeclPassthrough (DeclType { type_name; _ }) ->
+    Format.fprintf fmt "type %s" type_name
+  | EDeclPassthrough (DeclImport { module_path; _ }) ->
+    Format.fprintf fmt "import %s" module_path
+  | EDeclPassthrough (DeclRequire _) ->
+    Format.pp_print_string fmt "require ..."
+  | EDeclPassthrough _ ->
+    Format.pp_print_string fmt "..."
+
+let dump_program (prog : eprogram) : string =
+  let buf = Buffer.create 512 in
+  let fmt = Format.formatter_of_buffer buf in
+  List.iter (fun d ->
+      pp_edecl fmt d;
+      Format.pp_print_char fmt '\n') prog;
+  Format.pp_print_flush fmt ();
+  Buffer.contents buf

--- a/test/dune
+++ b/test/dune
@@ -44,6 +44,11 @@
  (libraries wasm_encode alcotest))
 
 (test
+ (name test_elaboration)
+ (modules test_elaboration)
+ (libraries axiom_lib alcotest str))
+
+(test
  (name test_build_pipeline)
  (modules test_build_pipeline)
  (libraries axiom_lib alcotest)

--- a/test/test_elaboration.ml
+++ b/test/test_elaboration.ml
@@ -1,0 +1,335 @@
+open Axiom_lib.Elaboration
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let elaborate_src src =
+  let tokens = Axiom_lib.Lexer.tokenize src in
+  let prog   = Axiom_lib.Parser.parse_program tokens in
+  ignore (Axiom_lib.Typechecker.check_program prog);
+  elaborate_program prog
+
+(** Render an elaborated program to a string for structural assertions. *)
+let dump src = dump_program (elaborate_src src)
+
+(** Find the first [EDeclFn] matching [name] in an elaborated program. *)
+let find_fn name prog =
+  let rec search ds =
+    List.find_map (fun d ->
+        match d.edecl_desc with
+        | EDeclFn f when f.fn_name = name -> Some f
+        | EDeclModule { body; _ } -> search body
+        | _ -> None) ds
+  in
+  match search prog with
+  | Some f -> f
+  | None   -> Alcotest.failf "function '%s' not found in elaborated program" name
+
+(** Collect [EPerform] nodes in an [eexpr] (depth-first). *)
+let rec collect_performs acc e =
+  match e.edesc with
+  | EPerform p -> p :: acc
+  | EApp (f, args) ->
+    List.fold_left collect_performs (collect_performs acc f) args
+  | EFn { fn_body; _ } -> collect_performs acc fn_body
+  | ELet { value; body; _ } ->
+    collect_performs (collect_performs acc value) body
+  | EIf { cond; then_; else_ } ->
+    collect_performs
+      (collect_performs (collect_performs acc cond) then_) else_
+  | EDo stmts ->
+    List.fold_left (fun a s -> match s with
+        | EStmtExpr e | EStmtLet { value = e; _ } -> collect_performs a e)
+      acc stmts
+  | EHandle { handled; handlers } ->
+    let a = collect_performs acc handled in
+    List.fold_left (fun a h ->
+        List.fold_left (fun a oh -> collect_performs a oh.op_handler_body)
+          a h.op_handlers)
+      a handlers
+  | EMatch { scrutinee; arms } ->
+    List.fold_left (fun a arm -> collect_performs a arm.arm_body)
+      (collect_performs acc scrutinee) arms
+  | ELetrec (bs, body) ->
+    List.fold_left (fun a b -> collect_performs a b.letrec_body)
+      (collect_performs acc body) bs
+  | ERecord fields ->
+    List.fold_left (fun a (_, v) -> collect_performs a v) acc fields
+  | ERecordUpdate (e, fields) ->
+    List.fold_left (fun a (_, v) -> collect_performs a v)
+      (collect_performs acc e) fields
+  | EProject (e, _) -> collect_performs acc e
+  | _ -> acc
+
+(* ------------------------------------------------------------------ *)
+(* Pure programs: no evidence threading                                 *)
+(* ------------------------------------------------------------------ *)
+
+let test_pure_fn_no_ev_params () =
+  let prog = elaborate_src {|
+    fn add(x: Int, y: Int) -> Int ! pure { add(x, y) }
+  |} in
+  let f = find_fn "add" prog in
+  Alcotest.(check int) "pure fn has no evidence params" 0 (List.length f.ev_params)
+
+let test_pure_fn_body_unchanged () =
+  (* A pure let binding: elaboration should not inject any __ev_ variables. *)
+  let prog = elaborate_src {|
+    fn identity(x: Int) -> Int ! pure { x }
+  |} in
+  let f = find_fn "identity" prog in
+  (match f.decl_body.edesc with
+   | EVar "x" -> ()
+   | _ -> Alcotest.fail "expected body to be EVar \"x\"")
+
+let test_pure_call_no_ev_args () =
+  (* Calling a pure function should not prepend evidence arguments. *)
+  let prog = elaborate_src {|
+    fn double(x: Int) -> Int ! pure { add(x, x) }
+  |} in
+  let f = find_fn "double" prog in
+  (match f.decl_body.edesc with
+   | EApp (_, args) ->
+     let ev_args = List.filter (fun a -> match a.edesc with
+         | EVar v -> String.length v >= 4 && String.sub v 0 4 = "__ev"
+         | _ -> false) args in
+     Alcotest.(check int) "no evidence args for pure call" 0 (List.length ev_args)
+   | _ -> Alcotest.fail "expected App node")
+
+(* ------------------------------------------------------------------ *)
+(* Effectful functions: evidence parameters added                       *)
+(* ------------------------------------------------------------------ *)
+
+let console_effect = {|
+  effect Console {
+    print: (String) -> Unit,
+    read_line: () -> String
+  }
+|}
+
+let test_effectful_fn_gets_ev_param () =
+  let prog = elaborate_src (console_effect ^ {|
+    fn greet() -> Unit ! {Console} {
+      perform Console.print("hi")
+    }
+  |}) in
+  let f = find_fn "greet" prog in
+  Alcotest.(check int) "one evidence param" 1 (List.length f.ev_params);
+  let ep = List.hd f.ev_params in
+  Alcotest.(check string) "ev_effect is Console" "Console" ep.ev_effect;
+  Alcotest.(check string) "ev_name is __ev_Console" "__ev_Console" ep.ev_name
+
+let test_multiple_effects_ev_params () =
+  let prog = elaborate_src ({|
+    effect Log   { log:    (String) -> Unit }
+    effect Audit { record: (String) -> Unit }
+  |} ^ {|
+    fn log_and_audit(msg: String) -> Unit ! {Log, Audit} {
+      do {
+        perform Log.log(msg);
+        perform Audit.record(msg)
+      }
+    }
+  |}) in
+  let f = find_fn "log_and_audit" prog in
+  Alcotest.(check int) "two evidence params" 2 (List.length f.ev_params);
+  let names = List.map (fun ep -> ep.ev_effect) f.ev_params in
+  Alcotest.(check bool) "Log present"   true (List.mem "Log"   names);
+  Alcotest.(check bool) "Audit present" true (List.mem "Audit" names)
+
+(* ------------------------------------------------------------------ *)
+(* Perform nodes: annotated with evidence variable                      *)
+(* ------------------------------------------------------------------ *)
+
+let test_perform_annotated_with_ev_var () =
+  let prog = elaborate_src (console_effect ^ {|
+    fn say_hello() -> Unit ! {Console} {
+      perform Console.print("hello")
+    }
+  |}) in
+  let f = find_fn "say_hello" prog in
+  let performs = collect_performs [] f.decl_body in
+  Alcotest.(check int) "one perform" 1 (List.length performs);
+  let p = List.hd performs in
+  Alcotest.(check string) "ev_var is __ev_Console" "__ev_Console" p.ev_var;
+  Alcotest.(check string) "effect_name" "Console" p.effect_name;
+  Alcotest.(check string) "op_name" "print" p.op_name
+
+let test_perform_multiple_effects_correct_ev () =
+  let prog = elaborate_src ({|
+    effect Log { log: (String) -> Unit }
+    effect State<s> { get: () -> s, put: (s) -> Unit }
+  |} ^ {|
+    fn log_and_put(msg: String, v: Int) -> Unit ! {Log, State<Int>} {
+      do {
+        perform Log.log(msg);
+        perform State.put(v)
+      }
+    }
+  |}) in
+  let f = find_fn "log_and_put" prog in
+  let performs = collect_performs [] f.decl_body in
+  Alcotest.(check int) "two performs" 2 (List.length performs);
+  let find_op op_name =
+    List.find (fun p -> p.op_name = op_name) performs in
+  let log_p   = find_op "log" in
+  let state_p = find_op "put" in
+  Alcotest.(check string) "log uses __ev_Log"     "__ev_Log"   log_p.ev_var;
+  Alcotest.(check string) "put uses __ev_State"   "__ev_State" state_p.ev_var
+
+(* ------------------------------------------------------------------ *)
+(* Call sites: evidence threaded for effectful callees                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_call_effectful_fn_gets_ev_arg () =
+  let prog = elaborate_src (console_effect ^ {|
+    fn greet() -> Unit ! {Console} {
+      perform Console.print("hi")
+    }
+    fn run_greet() -> Unit ! {Console} {
+      greet()
+    }
+  |}) in
+  let f = find_fn "run_greet" prog in
+  (* The body should be EApp(EVar "greet", [EVar "__ev_Console"]) *)
+  (match f.decl_body.edesc with
+   | EApp (callee, args) ->
+     (match callee.edesc with
+      | EVar "greet" -> ()
+      | _ -> Alcotest.fail "expected callee EVar greet");
+     Alcotest.(check int) "one arg (the evidence)" 1 (List.length args);
+     (match (List.hd args).edesc with
+      | EVar "__ev_Console" -> ()
+      | EVar v -> Alcotest.failf "expected __ev_Console but got %s" v
+      | _ -> Alcotest.fail "expected EVar for evidence arg")
+   | _ -> Alcotest.fail "expected App node")
+
+(* ------------------------------------------------------------------ *)
+(* Handle: evidence created for handled effects                         *)
+(* ------------------------------------------------------------------ *)
+
+let test_handle_creates_ev_param () =
+  let prog = elaborate_src (console_effect ^ {|
+    fn run(k: (u: Unit) -> Unit ! {Console}) -> Unit ! pure {
+      handle k(()) with {
+        Console {
+          print(msg) => resume(())
+          read_line() => resume("")
+        }
+      }
+    }
+  |}) in
+  let f = find_fn "run" prog in
+  (match f.decl_body.edesc with
+   | EHandle { handlers; _ } ->
+     Alcotest.(check int) "one handler" 1 (List.length handlers);
+     let h = List.hd handlers in
+     Alcotest.(check string) "handler effect" "Console" h.effect_handler;
+     Alcotest.(check string) "ev_param effect" "Console" h.ev_param.ev_effect;
+     Alcotest.(check string) "ev_param name" "__ev_Console" h.ev_param.ev_name
+   | _ -> Alcotest.fail "expected EHandle node")
+
+let test_handle_handled_expr_sees_evidence () =
+  (* Use a named top-level function (greet) as the handled expression so the
+     elaborator can look up its effects in fn_env and thread evidence.
+     greet() is elaborated to greet(__ev_Console) inside the handle, because
+     the handle extends ev_env with __ev_Console for the handled scope. *)
+  let prog = elaborate_src (console_effect ^ {|
+    fn greet() -> Unit ! {Console} {
+      perform Console.print("hello")
+    }
+    fn run_handle() -> Unit ! pure {
+      handle greet() with {
+        Console {
+          print(msg) => resume(())
+          read_line() => resume("")
+        }
+      }
+    }
+  |}) in
+  let f = find_fn "run_handle" prog in
+  (match f.decl_body.edesc with
+   | EHandle { handled; _ } ->
+     (* handled = greet(__ev_Console) *)
+     (match handled.edesc with
+      | EApp (callee, args) ->
+        (match callee.edesc with
+         | EVar "greet" -> ()
+         | _ -> Alcotest.fail "expected callee to be greet");
+        let ev_args = List.filter (fun a -> match a.edesc with
+            | EVar v -> String.length v >= 5 && String.sub v 0 5 = "__ev_"
+            | _ -> false) args in
+        Alcotest.(check int) "evidence arg threaded into greet() inside handle" 1
+          (List.length ev_args)
+      | _ -> Alcotest.fail "expected App(greet, ...) as handled expression")
+   | _ -> Alcotest.fail "expected EHandle node")
+
+(* ------------------------------------------------------------------ *)
+(* Dump / round-trip: string output contains expected markers          *)
+(* ------------------------------------------------------------------ *)
+
+let test_dump_shows_ev_params () =
+  let out = dump (console_effect ^ {|
+    fn greet() -> Unit ! {Console} {
+      perform Console.print("hi")
+    }
+  |}) in
+  Alcotest.(check bool) "dump contains __ev_Console param"
+    true (let re = Str.regexp_string "__ev_Console" in
+          try ignore (Str.search_forward re out 0); true
+          with Not_found -> false)
+
+let test_dump_shows_perform_evidence () =
+  let out = dump (console_effect ^ {|
+    fn greet() -> Unit ! {Console} {
+      perform Console.print("hello")
+    }
+  |}) in
+  (* The printer emits "perform[__ev_Console] Console.print(...)" *)
+  Alcotest.(check bool) "dump contains perform[__ev_Console]"
+    true (let re = Str.regexp_string "perform[__ev_Console]" in
+          try ignore (Str.search_forward re out 0); true
+          with Not_found -> false)
+
+let test_dump_pure_fn_no_ev () =
+  let out = dump {|
+    fn square(x: Int) -> Int ! pure { mul(x, x) }
+  |} in
+  Alcotest.(check bool) "dump of pure fn has no __ev marker"
+    true (not (let re = Str.regexp_string "__ev" in
+               try ignore (Str.search_forward re out 0); true
+               with Not_found -> false))
+
+(* ------------------------------------------------------------------ *)
+(* Test registration                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let () =
+  Alcotest.run "elaboration" [
+    "pure programs", [
+      Alcotest.test_case "pure fn has no evidence params"  `Quick test_pure_fn_no_ev_params;
+      Alcotest.test_case "pure fn body unchanged"          `Quick test_pure_fn_body_unchanged;
+      Alcotest.test_case "pure call has no evidence args"  `Quick test_pure_call_no_ev_args;
+    ];
+    "effectful functions", [
+      Alcotest.test_case "effectful fn gets ev param"      `Quick test_effectful_fn_gets_ev_param;
+      Alcotest.test_case "multiple effects get ev params"  `Quick test_multiple_effects_ev_params;
+    ];
+    "perform nodes", [
+      Alcotest.test_case "perform annotated with ev_var"   `Quick test_perform_annotated_with_ev_var;
+      Alcotest.test_case "perform with multiple effects"   `Quick test_perform_multiple_effects_correct_ev;
+    ];
+    "call sites", [
+      Alcotest.test_case "call effectful fn gets ev arg"   `Quick test_call_effectful_fn_gets_ev_arg;
+    ];
+    "handle nodes", [
+      Alcotest.test_case "handle creates ev_param"         `Quick test_handle_creates_ev_param;
+      Alcotest.test_case "handle: handled expr sees ev"    `Quick test_handle_handled_expr_sees_evidence;
+    ];
+    "dump / round-trip", [
+      Alcotest.test_case "dump shows ev params"            `Quick test_dump_shows_ev_params;
+      Alcotest.test_case "dump shows perform evidence"     `Quick test_dump_shows_perform_evidence;
+      Alcotest.test_case "dump of pure fn has no ev"       `Quick test_dump_pure_fn_no_ev;
+    ];
+  ]


### PR DESCRIPTION
Closes #40

## Summary

- Adds `lib/elaboration.ml` with a post-typecheck elaboration pass that rewrites the typed `Ast.program` into an `Eprogram` where effect evidence is made explicit.
- Pure functions are structurally identical post-elaboration (zero evidence params, no extra call arguments).
- Wires `elaborate_program` into `bin/main.ml` after typechecking.

## What the elaboration pass does

**Evidence parameters on functions**: Every `DeclFn` or `Fn` literal whose effect annotation admits effects gets one explicit `evidence_param` per named effect (e.g. `{Console, State<Int>}` → `[__ev_Console, __ev_State]`), prepended to the parameter list in the elaborated IR.

**Evidence threaded at call sites**: When the callee is a known top-level function (or a `Fn` literal with an effect annotation), the elaborator prepends the matching evidence variables from the ambient scope as leading arguments.

**`Perform` nodes annotated**: Each `EPerform` node carries an `ev_var` field naming the evidence variable in scope for that effect, ready for the next codegen sub-issue.

**`Handle` nodes preserved**: Each `EHandle` handler carries an `ev_param` (the evidence created for that effect). The handled expression is elaborated under an extended ambient that includes evidence for all handled effects; handler bodies are elaborated under the outer ambient.

## Test plan

- [x] 13 new tests in `test/test_elaboration.ml` covering pure-identity, effectful params, perform annotation, call-site threading, handle evidence, and dump round-trips.
- [x] All existing tests continue to pass (`dune test` exits 0).

https://claude.ai/code/session_01RtH5asHRYVzzyBoTMwqiTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtH5asHRYVzzyBoTMwqiTM)_