### PR TITLE
Add verify_types MCP tool

### DIFF
--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -182,6 +182,9 @@ type state = {
   node_store          : Node_store.t;
 }
 
+let format_type_error msg =
+  Object [("message", String msg); ("line", Int 0); ("col", Int 0)]
+
 let tool_submit_module_schema =
   Object [
     ("name", String "submit_module");
@@ -193,6 +196,19 @@ let tool_submit_module_schema =
         ("module_name", Object [("type", String "string")]);
       ]);
       ("required", Array [String "source"; String "module_name"]);
+    ]);
+  ]
+
+let tool_verify_types_schema =
+  Object [
+    ("name", String "verify_types");
+    ("description", String "Typecheck a working-form Axiom module and return any type errors; does not update server state");
+    ("inputSchema", Object [
+      ("type", String "object");
+      ("properties", Object [
+        ("source", Object [("type", String "string")]);
+      ]);
+      ("required", Array [String "source"]);
     ]);
   ]
 
@@ -209,11 +225,17 @@ let handle_submit_module state args =
     Hashtbl.replace state.modules module_name { typed_ast = ast; type_env; effect_env };
     Object [("ok", Bool true); ("hash", String hash_hex)]
   with Failure msg ->
-    Object [("ok", Bool false); ("error", Object [
-      ("message", String msg);
-      ("line",    Int 0);
-      ("col",     Int 0);
-    ])]
+    Object [("ok", Bool false); ("error", format_type_error msg)]
+
+let handle_verify_types args =
+  let source = match obj_get "source" args with String s -> s | _ -> "" in
+  try
+    let tokens = Lexer.tokenize source in
+    let ast    = Parser.parse_program tokens in
+    ignore (Typechecker.check_program ast);
+    Object [("errors", Array [])]
+  with Failure msg ->
+    Object [("errors", Array [format_type_error msg])]
 
 let handle state msg =
   let id     = obj_get "id" msg in
@@ -230,7 +252,7 @@ let handle state msg =
   | "notifications/initialized" ->
     ()
   | "tools/list" ->
-    send (response id (Object [("tools", Array [tool_submit_module_schema])]))
+    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema])]))
   | "tools/call" ->
     let params    = obj_get "params" msg in
     let tool_name = match obj_get "name" params with String s -> s | _ -> "" in
@@ -238,6 +260,13 @@ let handle state msg =
     (match tool_name with
      | "submit_module" ->
        let result = handle_submit_module state args in
+       send (response id (Object [
+         ("content", Array [
+           Object [("type", String "text"); ("text", String (json_to_string result))]
+         ])
+       ]))
+     | "verify_types" ->
+       let result = handle_verify_types args in
        send (response id (Object [
          ("content", Array [
            Object [("type", String "text"); ("text", String (json_to_string result))]

--- a/test/dune
+++ b/test/dune
@@ -53,3 +53,9 @@
  (modules test_build_pipeline)
  (libraries axiom_lib alcotest)
  (action (setenv AXIOM_EXE %{exe:../bin/main.exe} (run %{test}))))
+
+(test
+ (name test_mcp_server)
+ (modules test_mcp_server)
+ (libraries alcotest unix)
+ (action (setenv MCP_EXE %{exe:../bin/mcp_server.exe} (run %{test}))))

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -1,0 +1,255 @@
+let mcp_exe =
+  match Sys.getenv_opt "MCP_EXE" with
+  | Some p -> p
+  | None ->
+    let test_dir = Filename.dirname Sys.argv.(0) in
+    let candidates =
+      [ Filename.concat test_dir "../bin/mcp_server.exe"
+      ; Filename.concat test_dir "../bin/mcp_server"
+      ; Filename.concat (Sys.getcwd ()) "_build/default/bin/mcp_server.exe"
+      ; Filename.concat (Sys.getcwd ()) "_build/default/bin/mcp_server"
+      ]
+    in
+    (match List.find_opt Sys.file_exists candidates with
+     | Some p -> p
+     | None   -> "mcp_server")
+
+(* Launch the MCP server and return (write_line, read_line, close) *)
+let start_server () =
+  let (child_in_r, child_in_w)   = Unix.pipe () in
+  let (child_out_r, child_out_w) = Unix.pipe () in
+  let pid = Unix.create_process mcp_exe [| mcp_exe |]
+    child_in_r child_out_w Unix.stderr
+  in
+  Unix.close child_in_r;
+  Unix.close child_out_w;
+  let ic = Unix.in_channel_of_descr child_out_r in
+  let oc = Unix.out_channel_of_descr child_in_w in
+  let write_line s =
+    output_string oc (s ^ "\n");
+    flush oc
+  in
+  let read_line () = input_line ic in
+  let close () =
+    close_out_noerr oc;
+    close_in_noerr ic;
+    (try Unix.kill pid Sys.sigterm with _ -> ());
+    ignore (Unix.waitpid [] pid)
+  in
+  (write_line, read_line, close)
+
+(* Minimal JSON accessor helpers *)
+let json_field key json =
+  match json with
+  | `Assoc fields -> (match List.assoc_opt key fields with Some v -> v | None -> `Null)
+  | _ -> `Null
+
+let mini_parse s =
+  let len = String.length s in
+  let pos = ref 0 in
+  let peek () = if !pos < len then s.[!pos] else '\000' in
+  let next () = let c = peek () in incr pos; c in
+  let skip_ws () =
+    while !pos < len && (let c = peek () in c = ' ' || c = '\t' || c = '\n' || c = '\r')
+    do incr pos done
+  in
+  let expect c =
+    let got = next () in
+    if got <> c then failwith (Printf.sprintf "expected '%c' got '%c'" c got)
+  in
+  let parse_string () =
+    expect '"';
+    let buf = Buffer.create 16 in
+    let rec loop () =
+      match next () with
+      | '"' -> Buffer.contents buf
+      | '\\' ->
+        (match next () with
+         | '"'  -> Buffer.add_char buf '"'
+         | '\\' -> Buffer.add_char buf '\\'
+         | 'n'  -> Buffer.add_char buf '\n'
+         | 'r'  -> Buffer.add_char buf '\r'
+         | 't'  -> Buffer.add_char buf '\t'
+         | c    -> Buffer.add_char buf c);
+        loop ()
+      | c -> Buffer.add_char buf c; loop ()
+    in
+    loop ()
+  in
+  let rec parse_value () =
+    skip_ws ();
+    match peek () with
+    | '"' -> `String (parse_string ())
+    | '[' -> parse_array ()
+    | '{' -> parse_object ()
+    | 't' -> incr pos; expect 'r'; expect 'u'; expect 'e'; `Bool true
+    | 'f' -> incr pos; expect 'a'; expect 'l'; expect 's'; expect 'e'; `Bool false
+    | 'n' -> incr pos; expect 'u'; expect 'l'; expect 'l'; `Null
+    | c when c = '-' || (c >= '0' && c <= '9') ->
+      let start = !pos in
+      if peek () = '-' then incr pos;
+      while !pos < len && peek () >= '0' && peek () <= '9' do incr pos done;
+      `Int (int_of_string (String.sub s start (!pos - start)))
+    | c -> failwith (Printf.sprintf "unexpected '%c'" c)
+  and parse_array () =
+    expect '['; skip_ws ();
+    if peek () = ']' then (incr pos; `List [])
+    else begin
+      let items = ref [] in
+      let go = ref true in
+      while !go do
+        items := parse_value () :: !items;
+        skip_ws ();
+        (match peek () with
+         | ',' -> incr pos
+         | ']' -> incr pos; go := false
+         | _   -> failwith "expected ',' or ']'")
+      done;
+      `List (List.rev !items)
+    end
+  and parse_object () =
+    expect '{'; skip_ws ();
+    if peek () = '}' then (incr pos; `Assoc [])
+    else begin
+      let fields = ref [] in
+      let go = ref true in
+      while !go do
+        skip_ws ();
+        let k = parse_string () in
+        skip_ws (); expect ':';
+        let v = parse_value () in
+        fields := (k, v) :: !fields;
+        skip_ws ();
+        (match peek () with
+         | ',' -> incr pos
+         | '}' -> incr pos; go := false
+         | _   -> failwith "expected ',' or '}'")
+      done;
+      `Assoc (List.rev !fields)
+    end
+  in
+  parse_value ()
+
+let parse_response line =
+  let json = mini_parse line in
+  let result = json_field "result" json in
+  let content = json_field "content" result in
+  (match content with
+   | `List (item :: _) ->
+     let text = json_field "text" item in
+     (match text with `String s -> mini_parse s | _ -> `Null)
+   | _ -> result)
+
+let initialize write_line read_line =
+  write_line {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}|};
+  ignore (read_line ());
+  write_line {|{"jsonrpc":"2.0","id":null,"method":"notifications/initialized","params":{}}|}
+
+let well_typed_source = {|fn double(x: Int) -> Int ! pure { add(x, x) }|}
+
+let ill_typed_source = {|fn go() -> Unit ! pure { perform Nope.boom() }|}
+
+(* ------------------------------------------------------------------ *)
+(* Tests                                                               *)
+(* ------------------------------------------------------------------ *)
+
+let json_string_escape s =
+  let buf = Buffer.create (String.length s + 2) in
+  String.iter (function
+    | '"'  -> Buffer.add_string buf "\\\""
+    | '\\' -> Buffer.add_string buf "\\\\"
+    | '\n' -> Buffer.add_string buf "\\n"
+    | '\r' -> Buffer.add_string buf "\\r"
+    | '\t' -> Buffer.add_string buf "\\t"
+    | c    -> Buffer.add_char buf c) s;
+  Buffer.contents buf
+
+let verify_types_call id src =
+  Printf.sprintf
+    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"verify_types","arguments":{"source":"%s"}}}|}
+    id (json_string_escape src)
+
+let submit_module_call id src name =
+  Printf.sprintf
+    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"submit_module","arguments":{"source":"%s","module_name":"%s"}}}|}
+    id (json_string_escape src) (json_string_escape name)
+
+let test_verify_types_well_typed () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (verify_types_call 2 well_typed_source);
+    let result = parse_response (read_line ()) in
+    let errors = json_field "errors" result in
+    Alcotest.(check bool) "errors is empty list" true
+      (match errors with `List [] -> true | _ -> false)
+  )
+
+let test_verify_types_type_error () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (verify_types_call 2 ill_typed_source);
+    let result = parse_response (read_line ()) in
+    let errors = json_field "errors" result in
+    Alcotest.(check bool) "errors is non-empty" true
+      (match errors with `List (_ :: _) -> true | _ -> false);
+    (match errors with
+     | `List (err :: _) ->
+       let msg = json_field "message" err in
+       Alcotest.(check bool) "error has message field" true
+         (match msg with `String s -> String.length s > 0 | _ -> false);
+       let line = json_field "line" err in
+       Alcotest.(check bool) "error has line field" true
+         (match line with `Int _ -> true | _ -> false);
+       let col = json_field "col" err in
+       Alcotest.(check bool) "error has col field" true
+         (match col with `Int _ -> true | _ -> false)
+     | _ -> ())
+  )
+
+let test_verify_types_does_not_update_state () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (verify_types_call 2 ill_typed_source);
+    ignore (read_line ());
+    write_line (submit_module_call 3 well_typed_source "test");
+    let result = parse_response (read_line ()) in
+    let ok = json_field "ok" result in
+    Alcotest.(check bool) "submit_module still succeeds after verify_types" true
+      (match ok with `Bool true -> true | _ -> false)
+  )
+
+let test_tools_list_includes_verify_types () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
+    let line = read_line () in
+    let json = mini_parse line in
+    let result = json_field "result" json in
+    let tools = json_field "tools" result in
+    let names = match tools with
+      | `List items ->
+        List.filter_map (fun item ->
+          match json_field "name" item with
+          | `String s -> Some s
+          | _ -> None) items
+      | _ -> []
+    in
+    Alcotest.(check bool) "verify_types in tools/list" true
+      (List.mem "verify_types" names)
+  )
+
+let () =
+  ignore well_typed_source;
+  ignore ill_typed_source;
+  Alcotest.run "mcp_server" [
+    ("verify_types", [
+      Alcotest.test_case "well-typed program returns empty errors"    `Quick test_verify_types_well_typed;
+      Alcotest.test_case "ill-typed program returns non-empty errors" `Quick test_verify_types_type_error;
+      Alcotest.test_case "does not update server state"               `Quick test_verify_types_does_not_update_state;
+      Alcotest.test_case "appears in tools/list"                      `Quick test_tools_list_includes_verify_types;
+    ]);
+  ]


### PR DESCRIPTION
Closes #64

## Summary

- Registers `verify_types` in `tools/list` with input schema `{ source: string }`
- Runs lexer → parser → typechecker on `source` without updating server state
- Returns `{ "errors": [] }` on success, or `{ "errors": [{ "message": "...", "line": N, "col": N }] }` on failure
- Extracts a `format_type_error` helper shared with `submit_module`

## Test plan

- [ ] `verify_types` on a well-typed program returns `{ "errors": [] }`
- [ ] `verify_types` on a program with a type error returns a non-empty errors array with `message`, `line`, and `col` fields
- [ ] Calling `verify_types` does not alter previously submitted module state
- [ ] `verify_types` appears in `tools/list`
- [ ] All existing tests continue to pass (`dune test`)

https://claude.ai/code/session_015xqLAC9UKTGro1xiVNUvqP

---
_Generated by [Claude Code](https://claude.ai/code/session_015xqLAC9UKTGro1xiVNUvqP)_