### PR TITLE
Add query_signature MCP tool

### DIFF
--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -212,6 +212,20 @@ let tool_verify_types_schema =
     ]);
   ]
 
+let tool_query_signature_schema =
+  Object [
+    ("name", String "query_signature");
+    ("description", String "Return the type and effect signature of a named function from a previously submitted module");
+    ("inputSchema", Object [
+      ("type", String "object");
+      ("properties", Object [
+        ("module_name",   Object [("type", String "string")]);
+        ("function_name", Object [("type", String "string")]);
+      ]);
+      ("required", Array [String "module_name"; String "function_name"]);
+    ]);
+  ]
+
 let handle_submit_module state args =
   let source      = match obj_get "source"      args with String s -> s | _ -> "" in
   let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
@@ -237,6 +251,22 @@ let handle_verify_types args =
   with Failure msg ->
     Object [("errors", Array [format_type_error msg])]
 
+let handle_query_signature state args =
+  let module_name   = match obj_get "module_name"   args with String s -> s | _ -> "" in
+  let function_name = match obj_get "function_name" args with String s -> s | _ -> "" in
+  match Hashtbl.find_opt state.modules module_name with
+  | None ->
+    Object [("ok", Bool false);
+            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
+  | Some ms ->
+    match List.assoc_opt function_name ms.type_env with
+    | None ->
+      Object [("ok", Bool false);
+              ("error", String (Printf.sprintf "Function '%s' not found in module '%s'" function_name module_name))]
+    | Some scheme ->
+      let sig_str = Format.asprintf "%a" Typechecker.pp_ty scheme.body in
+      Object [("ok", Bool true); ("signature", String sig_str)]
+
 let handle state msg =
   let id     = obj_get "id" msg in
   let meth   = match obj_get "method" msg with String s -> s | _ -> "" in
@@ -252,7 +282,7 @@ let handle state msg =
   | "notifications/initialized" ->
     ()
   | "tools/list" ->
-    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema])]))
+    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema])]))
   | "tools/call" ->
     let params    = obj_get "params" msg in
     let tool_name = match obj_get "name" params with String s -> s | _ -> "" in
@@ -267,6 +297,13 @@ let handle state msg =
        ]))
      | "verify_types" ->
        let result = handle_verify_types args in
+       send (response id (Object [
+         ("content", Array [
+           Object [("type", String "text"); ("text", String (json_to_string result))]
+         ])
+       ]))
+     | "query_signature" ->
+       let result = handle_query_signature state args in
        send (response id (Object [
          ("content", Array [
            Object [("type", String "text"); ("text", String (json_to_string result))]

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -174,6 +174,11 @@ let submit_module_call id src name =
     {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"submit_module","arguments":{"source":"%s","module_name":"%s"}}}|}
     id (json_string_escape src) (json_string_escape name)
 
+let query_signature_call id module_name function_name =
+  Printf.sprintf
+    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_signature","arguments":{"module_name":"%s","function_name":"%s"}}}|}
+    id (json_string_escape module_name) (json_string_escape function_name)
+
 let test_verify_types_well_typed () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
@@ -242,6 +247,73 @@ let test_tools_list_includes_verify_types () =
       (List.mem "verify_types" names)
   )
 
+let test_query_signature_success () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 well_typed_source "mymod");
+    ignore (read_line ());
+    write_line (query_signature_call 3 "mymod" "double");
+    let result = parse_response (read_line ()) in
+    let ok = json_field "ok" result in
+    Alcotest.(check bool) "ok is true" true
+      (match ok with `Bool true -> true | _ -> false);
+    let sig_ = json_field "signature" result in
+    Alcotest.(check bool) "signature is a non-empty string" true
+      (match sig_ with `String s -> String.length s > 0 | _ -> false)
+  )
+
+let test_query_signature_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (query_signature_call 2 "nonexistent" "double");
+    let result = parse_response (read_line ()) in
+    let ok = json_field "ok" result in
+    Alcotest.(check bool) "ok is false" true
+      (match ok with `Bool false -> true | _ -> false);
+    let err = json_field "error" result in
+    Alcotest.(check bool) "error message is a non-empty string" true
+      (match err with `String s -> String.length s > 0 | _ -> false)
+  )
+
+let test_query_signature_function_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 well_typed_source "mymod");
+    ignore (read_line ());
+    write_line (query_signature_call 3 "mymod" "nonexistent_fn");
+    let result = parse_response (read_line ()) in
+    let ok = json_field "ok" result in
+    Alcotest.(check bool) "ok is false" true
+      (match ok with `Bool false -> true | _ -> false);
+    let err = json_field "error" result in
+    Alcotest.(check bool) "error message is a non-empty string" true
+      (match err with `String s -> String.length s > 0 | _ -> false)
+  )
+
+let test_query_signature_in_tools_list () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
+    let line = read_line () in
+    let json = mini_parse line in
+    let result = json_field "result" json in
+    let tools = json_field "tools" result in
+    let names = match tools with
+      | `List items ->
+        List.filter_map (fun item ->
+          match json_field "name" item with
+          | `String s -> Some s
+          | _ -> None) items
+      | _ -> []
+    in
+    Alcotest.(check bool) "query_signature in tools/list" true
+      (List.mem "query_signature" names)
+  )
+
 let () =
   ignore well_typed_source;
   ignore ill_typed_source;
@@ -251,5 +323,11 @@ let () =
       Alcotest.test_case "ill-typed program returns non-empty errors" `Quick test_verify_types_type_error;
       Alcotest.test_case "does not update server state"               `Quick test_verify_types_does_not_update_state;
       Alcotest.test_case "appears in tools/list"                      `Quick test_tools_list_includes_verify_types;
+    ]);
+    ("query_signature", [
+      Alcotest.test_case "returns signature for known function"              `Quick test_query_signature_success;
+      Alcotest.test_case "returns error when module not found"               `Quick test_query_signature_module_not_found;
+      Alcotest.test_case "returns error when function not found in module"   `Quick test_query_signature_function_not_found;
+      Alcotest.test_case "appears in tools/list"                             `Quick test_query_signature_in_tools_list;
     ]);
   ]


### PR DESCRIPTION
## Summary

- Adds the `query_signature` MCP tool to `bin/mcp_server.ml`
- Given a previously submitted module and a function name, looks up the function's type and effect signature from the in-memory type environment and returns it rendered via `Typechecker.pp_ty`
- Returns descriptive errors when the module or function name is not found
- Registers the tool in `tools/list` with input schema `{ module_name: string, function_name: string }`

Closes #65

## Test plan

- [ ] `test_query_signature_success` — submits a module, queries a known function, checks `ok: true` and a non-empty `signature` string
- [ ] `test_query_signature_module_not_found` — queries an unknown module, checks `ok: false` with an error message
- [ ] `test_query_signature_function_not_found` — submits a module, queries an unknown function, checks `ok: false` with an error message
- [ ] `test_query_signature_in_tools_list` — verifies `query_signature` appears in `tools/list`
- [ ] All existing tests continue to pass (`dune test`)

https://claude.ai/code/session_01B13XUStCbGB5TsRMFvmx8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01B13XUStCbGB5TsRMFvmx8J)_