### PR TITLE
Add query_interface MCP tool

### DIFF
--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -226,6 +226,19 @@ let tool_query_signature_schema =
     ]);
   ]
 
+let tool_query_interface_schema =
+  Object [
+    ("name", String "query_interface");
+    ("description", String "Return the public API of a previously submitted module: pub type aliases, pub effect declarations, and pub function signatures");
+    ("inputSchema", Object [
+      ("type", String "object");
+      ("properties", Object [
+        ("module_name", Object [("type", String "string")]);
+      ]);
+      ("required", Array [String "module_name"]);
+    ]);
+  ]
+
 let handle_submit_module state args =
   let source      = match obj_get "source"      args with String s -> s | _ -> "" in
   let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
@@ -267,6 +280,38 @@ let handle_query_signature state args =
       let sig_str = Format.asprintf "%a" Typechecker.pp_ty scheme.body in
       Object [("ok", Bool true); ("signature", String sig_str)]
 
+let render_interface_decl decl =
+  match decl.Ast.decl_desc with
+  | Ast.DeclFn { pub = true; fn_name; type_params; params; return_type; effects; _ } ->
+    let tp_s =
+      if type_params = [] then ""
+      else "<" ^ String.concat ", " type_params ^ ">"
+    in
+    let ann = match return_type, effects with
+      | Some ret, Some eff ->
+        " -> " ^ Printer.print_type_expr ret ^ " ! " ^ Printer.print_effect_set eff
+      | Some ret, None -> " -> " ^ Printer.print_type_expr ret
+      | _ -> ""
+    in
+    Some ("pub fn " ^ fn_name ^ tp_s ^ "(" ^
+          String.concat ", " (List.map Printer.print_param params) ^ ")" ^ ann)
+  | Ast.DeclType { pub = true; _ } ->
+    Some (Printer.print_decl decl)
+  | Ast.DeclEffect { pub = true; _ } ->
+    Some (Printer.print_decl decl)
+  | _ -> None
+
+let handle_query_interface state args =
+  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
+  match Hashtbl.find_opt state.modules module_name with
+  | None ->
+    Object [("ok", Bool false);
+            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
+  | Some ms ->
+    let lines = List.filter_map render_interface_decl ms.typed_ast in
+    let iface = String.concat "\n" lines in
+    Object [("interface", String iface)]
+
 let handle state msg =
   let id     = obj_get "id" msg in
   let meth   = match obj_get "method" msg with String s -> s | _ -> "" in
@@ -282,7 +327,7 @@ let handle state msg =
   | "notifications/initialized" ->
     ()
   | "tools/list" ->
-    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema])]))
+    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema; tool_query_interface_schema])]))
   | "tools/call" ->
     let params    = obj_get "params" msg in
     let tool_name = match obj_get "name" params with String s -> s | _ -> "" in
@@ -304,6 +349,13 @@ let handle state msg =
        ]))
      | "query_signature" ->
        let result = handle_query_signature state args in
+       send (response id (Object [
+         ("content", Array [
+           Object [("type", String "text"); ("text", String (json_to_string result))]
+         ])
+       ]))
+     | "query_interface" ->
+       let result = handle_query_interface state args in
        send (response id (Object [
          ("content", Array [
            Object [("type", String "text"); ("text", String (json_to_string result))]

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -179,6 +179,11 @@ let query_signature_call id module_name function_name =
     {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_signature","arguments":{"module_name":"%s","function_name":"%s"}}}|}
     id (json_string_escape module_name) (json_string_escape function_name)
 
+let query_interface_call id module_name =
+  Printf.sprintf
+    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_interface","arguments":{"module_name":"%s"}}}|}
+    id (json_string_escape module_name)
+
 let test_verify_types_well_typed () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
@@ -314,6 +319,93 @@ let test_query_signature_in_tools_list () =
       (List.mem "query_signature" names)
   )
 
+let mixed_visibility_source =
+  {|pub fn add_one(x: Int) -> Int ! pure { add(x, 1) }
+fn internal_helper(x: Int) -> Int ! pure { x }
+pub type Color = | Red | Green | Blue|}
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack and nlen = String.length needle in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let found = ref false in
+    for i = 0 to hlen - nlen do
+      if not !found &&
+         String.sub haystack i nlen = needle then
+        found := true
+    done;
+    !found
+
+let test_query_interface_returns_only_pub () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 mixed_visibility_source "mymod");
+    ignore (read_line ());
+    write_line (query_interface_call 3 "mymod");
+    let result = parse_response (read_line ()) in
+    let iface = json_field "interface" result in
+    let iface_str = match iface with `String s -> s | _ -> "" in
+    Alcotest.(check bool) "interface contains pub fn" true
+      (contains_substring iface_str "pub fn add_one");
+    Alcotest.(check bool) "interface contains pub type" true
+      (contains_substring iface_str "pub type Color");
+    Alcotest.(check bool) "interface excludes private fn" true
+      (not (contains_substring iface_str "internal_helper"))
+  )
+
+let test_query_interface_fn_has_no_body () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 mixed_visibility_source "mymod");
+    ignore (read_line ());
+    write_line (query_interface_call 3 "mymod");
+    let result = parse_response (read_line ()) in
+    let iface = json_field "interface" result in
+    let iface_str = match iface with `String s -> s | _ -> "" in
+    Alcotest.(check bool) "interface is a non-empty string" true
+      (String.length iface_str > 0);
+    Alcotest.(check bool) "interface has no fn body braces" true
+      (not (String.contains iface_str '{'))
+  )
+
+let test_query_interface_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (query_interface_call 2 "nonexistent");
+    let result = parse_response (read_line ()) in
+    let ok = json_field "ok" result in
+    Alcotest.(check bool) "ok is false" true
+      (match ok with `Bool false -> true | _ -> false);
+    let err = json_field "error" result in
+    Alcotest.(check bool) "error is non-empty string" true
+      (match err with `String s -> String.length s > 0 | _ -> false)
+  )
+
+let test_query_interface_in_tools_list () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
+    let line = read_line () in
+    let json = mini_parse line in
+    let result = json_field "result" json in
+    let tools = json_field "tools" result in
+    let names = match tools with
+      | `List items ->
+        List.filter_map (fun item ->
+          match json_field "name" item with
+          | `String s -> Some s
+          | _ -> None) items
+      | _ -> []
+    in
+    Alcotest.(check bool) "query_interface in tools/list" true
+      (List.mem "query_interface" names)
+  )
+
 let () =
   ignore well_typed_source;
   ignore ill_typed_source;
@@ -329,5 +421,11 @@ let () =
       Alcotest.test_case "returns error when module not found"               `Quick test_query_signature_module_not_found;
       Alcotest.test_case "returns error when function not found in module"   `Quick test_query_signature_function_not_found;
       Alcotest.test_case "appears in tools/list"                             `Quick test_query_signature_in_tools_list;
+    ]);
+    ("query_interface", [
+      Alcotest.test_case "returns only pub declarations"                     `Quick test_query_interface_returns_only_pub;
+      Alcotest.test_case "function signatures have no body"                  `Quick test_query_interface_fn_has_no_body;
+      Alcotest.test_case "returns error when module not found"               `Quick test_query_interface_module_not_found;
+      Alcotest.test_case "appears in tools/list"                             `Quick test_query_interface_in_tools_list;
     ]);
   ]


### PR DESCRIPTION
Closes #66

## Summary

- Adds the `query_interface` tool to the MCP server
- Registers it in `tools/list` with input schema `{ module_name: string }`
- Walks the typed `Ast.program` collecting `pub` declarations only:
  - `DeclFn` → renders the signature without body (`pub fn foo(x: T) -> U ! E`)
  - `DeclType` → renders the full type declaration via `Printer.print_decl`
  - `DeclEffect` → renders the full effect declaration via `Printer.print_decl`
  - Private declarations are silently excluded
- Returns `{ "interface": "..." }` on success, `{ "ok": false, "error": "..." }` when the module has not been submitted

## Test plan

- [ ] `query_interface` returns only `pub` declarations (pub fn + pub type present; private fn absent)
- [ ] Function signatures have no body (no `{` in output)
- [ ] Returns a clear error when `module_name` has not been submitted
- [ ] Tool appears in `tools/list`
- [ ] All existing `verify_types` and `query_signature` tests still pass

https://claude.ai/code/session_01RMsKA5YuWfWzE2RHWrr3w2

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMsKA5YuWfWzE2RHWrr3w2)_