### PR TITLE
Add verify_exhaustive MCP tool

### DIFF
--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -239,6 +239,19 @@ let tool_query_interface_schema =
     ]);
   ]
 
+let tool_verify_exhaustive_schema =
+  Object [
+    ("name", String "verify_exhaustive");
+    ("description", String "Check every match expression in a previously submitted module for non-exhaustive patterns; returns warnings with missing constructor names");
+    ("inputSchema", Object [
+      ("type", String "object");
+      ("properties", Object [
+        ("module_name", Object [("type", String "string")]);
+      ]);
+      ("required", Array [String "module_name"]);
+    ]);
+  ]
+
 let handle_submit_module state args =
   let source      = match obj_get "source"      args with String s -> s | _ -> "" in
   let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
@@ -301,6 +314,21 @@ let render_interface_decl decl =
     Some (Printer.print_decl decl)
   | _ -> None
 
+let handle_verify_exhaustive state args =
+  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
+  match Hashtbl.find_opt state.modules module_name with
+  | None ->
+    Object [("ok", Bool false);
+            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
+  | Some ms ->
+    let warnings = Typechecker.collect_match_warnings ms.typed_ast in
+    let json_warnings = List.map (fun (w : Typechecker.match_warning) ->
+        Object [
+          ("location", Object [("line", Int w.mw_line); ("col", Int w.mw_col)]);
+          ("missing_patterns", Array (List.map (fun s -> String s) w.mw_missing));
+        ]) warnings in
+    Object [("warnings", Array json_warnings)]
+
 let handle_query_interface state args =
   let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
   match Hashtbl.find_opt state.modules module_name with
@@ -327,7 +355,7 @@ let handle state msg =
   | "notifications/initialized" ->
     ()
   | "tools/list" ->
-    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema; tool_query_interface_schema])]))
+    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema; tool_query_interface_schema; tool_verify_exhaustive_schema])]))
   | "tools/call" ->
     let params    = obj_get "params" msg in
     let tool_name = match obj_get "name" params with String s -> s | _ -> "" in
@@ -356,6 +384,13 @@ let handle state msg =
        ]))
      | "query_interface" ->
        let result = handle_query_interface state args in
+       send (response id (Object [
+         ("content", Array [
+           Object [("type", String "text"); ("text", String (json_to_string result))]
+         ])
+       ]))
+     | "verify_exhaustive" ->
+       let result = handle_verify_exhaustive state args in
        send (response id (Object [
          ("content", Array [
            Object [("type", String "text"); ("text", String (json_to_string result))]

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -1482,3 +1482,103 @@ let check_program (prog : program) : env * effect_env =
   in
   List.iter check_decl prog;
   (env0, eenv0)
+
+(* ------------------------------------------------------------------ *)
+(* Exhaustiveness warning collection (non-raising)                     *)
+(* ------------------------------------------------------------------ *)
+
+type match_warning = {
+  mw_line    : int;
+  mw_col     : int;
+  mw_missing : string list;
+}
+
+(** Walk [prog] and return one [match_warning] per non-exhaustive match
+    expression.  Uses [type_ctor_env] (rebuilt from [prog]) for ADT
+    constructor lookup.  Because the AST carries no source positions,
+    [mw_line] and [mw_col] are always 0. *)
+let collect_match_warnings (prog : program) : match_warning list =
+  type_ctor_env := stdlib_type_ctor_env @ build_type_ctor_env prog;
+  let warnings = ref [] in
+  let add_warning missing =
+    warnings := { mw_line = 0; mw_col = 0; mw_missing = missing } :: !warnings
+  in
+  let check_match_pats arms =
+    let flat =
+      List.concat_map flatten_or_pat (List.map (fun a -> a.pattern) arms)
+    in
+    if List.exists
+        (fun p -> match p.pat_desc with PWild | PVar _ -> true | _ -> false)
+        flat
+    then ()
+    else begin
+      let ctor_names = List.filter_map (fun p ->
+          match p.pat_desc with PCtor (n, _) -> Some n | _ -> None) flat in
+      let has_true  = List.exists (fun p -> p.pat_desc = PLitTrue)  flat in
+      let has_false = List.exists (fun p -> p.pat_desc = PLitFalse) flat in
+      if ctor_names <> [] then begin
+        match List.find_opt (fun (_, ctors) ->
+            List.exists (fun c -> List.mem c ctor_names) ctors)
+            !type_ctor_env
+        with
+        | None -> ()
+        | Some (_, all_ctors) ->
+          let missing =
+            List.filter (fun c -> not (List.mem c ctor_names)) all_ctors
+          in
+          if missing <> [] then add_warning missing
+      end else if has_true || has_false then begin
+        let missing =
+          (if has_true  then [] else ["true"]) @
+          (if has_false then [] else ["false"])
+        in
+        if missing <> [] then add_warning missing
+      end
+    end
+  in
+  let rec walk_expr e =
+    match e.desc with
+    | Match { scrutinee; arms } ->
+      walk_expr scrutinee;
+      List.iter (fun arm -> walk_expr arm.arm_body) arms;
+      check_match_pats arms
+    | Let { value; body; _ } ->
+      walk_expr value; walk_expr body
+    | App (f, args) ->
+      walk_expr f; List.iter walk_expr args
+    | Fn { fn_body; _ } ->
+      walk_expr fn_body
+    | If { cond; then_; else_ } ->
+      walk_expr cond; walk_expr then_; walk_expr else_
+    | Do stmts ->
+      List.iter (function
+        | StmtLet { value; _ } -> walk_expr value
+        | StmtExpr e -> walk_expr e) stmts
+    | Letrec (bindings, body) ->
+      List.iter (fun b -> walk_expr b.letrec_body) bindings;
+      walk_expr body
+    | Record fields ->
+      List.iter (fun (_, e) -> walk_expr e) fields
+    | RecordUpdate (base, fields) ->
+      walk_expr base; List.iter (fun (_, e) -> walk_expr e) fields
+    | Project (e, _) ->
+      walk_expr e
+    | Perform { args; _ } ->
+      List.iter walk_expr args
+    | Handle { handled; handlers } ->
+      walk_expr handled;
+      List.iter (fun h ->
+          List.iter (fun op -> walk_expr op.op_handler_body) h.op_handlers;
+          Option.iter (fun r -> walk_expr r.return_body) h.return_handler)
+        handlers
+    | Var _ | IntLit _ | FloatLit _ | StringLit _
+    | BoolLit _ | UnitLit -> ()
+  in
+  let rec walk_decl d =
+    match d.decl_desc with
+    | DeclFn { decl_body; _ } -> walk_expr decl_body
+    | DeclModule { body; _ } -> List.iter walk_decl body
+    | DeclType _ | DeclEffect _ | DeclRequire _ | DeclImport _ -> ()
+  in
+  List.iter walk_decl prog;
+  List.rev !warnings

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -406,6 +406,69 @@ let test_query_interface_in_tools_list () =
       (List.mem "query_interface" names)
   )
 
+let verify_exhaustive_call id module_name =
+  Printf.sprintf
+    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"verify_exhaustive","arguments":{"module_name":"%s"}}}|}
+    id (json_string_escape module_name)
+
+let exhaustive_source =
+  {|type Color = | Red | Green | Blue
+fn describe(c: Color) -> Int ! pure {
+  match c with {
+    | Red   => 0
+    | Green => 1
+    | Blue  => 2
+  }
+}|}
+
+let test_verify_exhaustive_in_tools_list () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
+    let line = read_line () in
+    let json = mini_parse line in
+    let result = json_field "result" json in
+    let tools = json_field "tools" result in
+    let names = match tools with
+      | `List items ->
+        List.filter_map (fun item ->
+          match json_field "name" item with
+          | `String s -> Some s
+          | _ -> None) items
+      | _ -> []
+    in
+    Alcotest.(check bool) "verify_exhaustive in tools/list" true
+      (List.mem "verify_exhaustive" names)
+  )
+
+let test_verify_exhaustive_exhaustive_module () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 exhaustive_source "mymod");
+    ignore (read_line ());
+    write_line (verify_exhaustive_call 3 "mymod");
+    let result = parse_response (read_line ()) in
+    let warnings = json_field "warnings" result in
+    Alcotest.(check bool) "warnings is empty list" true
+      (match warnings with `List [] -> true | _ -> false)
+  )
+
+let test_verify_exhaustive_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (verify_exhaustive_call 2 "nonexistent");
+    let result = parse_response (read_line ()) in
+    let ok = json_field "ok" result in
+    Alcotest.(check bool) "ok is false" true
+      (match ok with `Bool false -> true | _ -> false);
+    let err = json_field "error" result in
+    Alcotest.(check bool) "error is non-empty string" true
+      (match err with `String s -> String.length s > 0 | _ -> false)
+  )
+
 let () =
   ignore well_typed_source;
   ignore ill_typed_source;
@@ -427,5 +490,10 @@ let () =
       Alcotest.test_case "function signatures have no body"                  `Quick test_query_interface_fn_has_no_body;
       Alcotest.test_case "returns error when module not found"               `Quick test_query_interface_module_not_found;
       Alcotest.test_case "appears in tools/list"                             `Quick test_query_interface_in_tools_list;
+    ]);
+    ("verify_exhaustive", [
+      Alcotest.test_case "appears in tools/list"                             `Quick test_verify_exhaustive_in_tools_list;
+      Alcotest.test_case "returns empty warnings for exhaustive module"      `Quick test_verify_exhaustive_exhaustive_module;
+      Alcotest.test_case "returns error when module not found"               `Quick test_verify_exhaustive_module_not_found;
     ]);
   ]

--- a/test/test_typechecker.ml
+++ b/test/test_typechecker.ml
@@ -1469,6 +1469,79 @@ let test_stdlib_example_02_result () =
     |}
 
 (* ------------------------------------------------------------------ *)
+(* collect_match_warnings tests                                         *)
+(* ------------------------------------------------------------------ *)
+
+let test_collect_warnings_exhaustive () =
+  let prog = parse_program
+      {|
+        type Color = | Red | Green | Blue
+
+        fn describe(c: Color) -> Int ! pure {
+          match c with {
+            | Red   => 0
+            | Green => 1
+            | Blue  => 2
+          }
+        }
+      |}
+  in
+  let warnings = collect_match_warnings prog in
+  Alcotest.(check int) "no warnings for exhaustive match" 0 (List.length warnings)
+
+let test_collect_warnings_non_exhaustive () =
+  let prog = parse_program
+      {|
+        type Color = | Red | Green | Blue
+
+        fn bad(c: Color) -> Int ! pure {
+          match c with {
+            | Red => 0
+          }
+        }
+      |}
+  in
+  let warnings = collect_match_warnings prog in
+  Alcotest.(check bool) "one warning" true (List.length warnings = 1);
+  let w = List.hd warnings in
+  Alcotest.(check bool) "Green missing" true (List.mem "Green" w.mw_missing);
+  Alcotest.(check bool) "Blue missing"  true (List.mem "Blue"  w.mw_missing)
+
+let test_collect_warnings_wildcard_covers () =
+  let prog = parse_program
+      {|
+        type Color = | Red | Green | Blue
+
+        fn any(c: Color) -> Int ! pure {
+          match c with {
+            | Red => 0
+            | _   => 1
+          }
+        }
+      |}
+  in
+  let warnings = collect_match_warnings prog in
+  Alcotest.(check int) "wildcard suppresses warning" 0 (List.length warnings)
+
+let test_collect_warnings_multiple_matches () =
+  let prog = parse_program
+      {|
+        type AB = | A | B
+        type XY = | X | Y
+
+        fn f(a: AB) -> Int ! pure {
+          match a with { | A => 0 }
+        }
+
+        fn g(x: XY) -> Int ! pure {
+          match x with { | X => 0 }
+        }
+      |}
+  in
+  let warnings = collect_match_warnings prog in
+  Alcotest.(check int) "two non-exhaustive matches produce two warnings" 2 (List.length warnings)
+
+(* ------------------------------------------------------------------ *)
 (* Test runner                                                          *)
 (* ------------------------------------------------------------------ *)
 
@@ -1615,6 +1688,12 @@ let () =
         ; Alcotest.test_case "record literal field"      `Quick test_exhaustive_record_literal_field
         ; Alcotest.test_case "record multi-pattern"      `Quick test_exhaustive_record_multi_pattern
         ; Alcotest.test_case "record open pattern"       `Quick test_exhaustive_record_open_pattern
+        ] )
+    ; ( "collect_match_warnings",
+        [ Alcotest.test_case "exhaustive match — no warnings"         `Quick test_collect_warnings_exhaustive
+        ; Alcotest.test_case "non-exhaustive match — missing ctors"   `Quick test_collect_warnings_non_exhaustive
+        ; Alcotest.test_case "wildcard arm covers all"                `Quick test_collect_warnings_wildcard_covers
+        ; Alcotest.test_case "multiple non-exhaustive matches"        `Quick test_collect_warnings_multiple_matches
         ] )
     ; ( "open-effect-rows",
         [ Alcotest.test_case "open row parses"           `Quick test_row_var_open_row_parses


### PR DESCRIPTION
## Summary

- Adds `verify_exhaustive` MCP tool that checks every `match` expression in a previously-submitted module for non-exhaustive constructor coverage
- Adds `collect_match_warnings` to `typechecker.ml` — a non-raising AST walk that reuses the existing `type_ctor_env` / `flatten_or_pat` infrastructure to detect missing ADT constructors and Bool literal arms
- Returns `{"warnings": []}` for fully-exhaustive modules; returns one entry per non-exhaustive match with `{"location": {"line": 0, "col": 0}, "missing_patterns": ["Ctor", ...]}`

Closes #67

## Test plan

- [ ] `dune test` passes (all existing + new tests green)
- [ ] `collect_match_warnings` unit tests: exhaustive module → no warnings, non-exhaustive → correct missing ctors, wildcard arm suppresses warning, multiple matches each produce a warning
- [ ] MCP integration tests: tool appears in `tools/list`, exhaustive submitted module returns empty warnings, unknown module returns error

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAAasdLDeVjs1mbsQFBabC)_