### PR TITLE
Add query_effects MCP tool

### DIFF
--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -390,6 +390,89 @@ let handle_query_interface state args =
     let iface = String.concat "\n" lines in
     Object [("interface", String iface)]
 
+let rec ty_deref = function
+  | Typechecker.TyMeta { Typechecker.inst = Some t; _ } -> ty_deref t
+  | t -> t
+
+let rec row_deref = function
+  | Typechecker.RMeta { Typechecker.rinst = Some r; _ } -> row_deref r
+  | r -> r
+
+let collect_row_effects row =
+  let rec go acc r =
+    match row_deref r with
+    | Typechecker.RPure -> List.rev acc
+    | Typechecker.RCons (e, rest) -> go (e.Typechecker.eff_name :: acc) rest
+    | Typechecker.RMeta _ -> List.rev acc
+  in
+  go [] row
+
+(* Walk a (possibly curried) function type to find the innermost arrow's effect
+   row, which is where fn_scheme_of_decl places the declared effects. Returns
+   None for 0-parameter functions whose scheme body is not a TyFun. *)
+let rec fn_effect_row ty =
+  match ty_deref ty with
+  | Typechecker.TyForall (_, t) -> fn_effect_row t
+  | Typechecker.TyFun (_, ret, row) ->
+    (match ty_deref ret with
+     | Typechecker.TyFun _ as inner -> fn_effect_row inner
+     | _ -> Some row)
+  | _ -> None
+
+let effect_names_of_decl_annotation = function
+  | None | Some Ast.Pure -> []
+  | Some (Ast.Effects (ts, _)) ->
+    List.filter_map (function
+      | Ast.TyName n -> Some n
+      | Ast.TyApp (n, _) -> Some n
+      | _ -> None) ts
+
+let tool_query_effects_schema =
+  Object [
+    ("name", String "query_effects");
+    ("description", String "Return a map from each effect name to the list of top-level functions that perform it in a previously submitted module");
+    ("inputSchema", Object [
+      ("type", String "object");
+      ("properties", Object [
+        ("module_name", Object [("type", String "string")]);
+      ]);
+      ("required", Array [String "module_name"]);
+    ]);
+  ]
+
+let handle_query_effects state args =
+  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
+  match Hashtbl.find_opt state.modules module_name with
+  | None ->
+    Object [("ok", Bool false);
+            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
+  | Some ms ->
+    let effects_tbl : (string, string list) Hashtbl.t = Hashtbl.create 8 in
+    let add_fn_to_effect eff_name fn_name =
+      let existing = Option.value ~default:[] (Hashtbl.find_opt effects_tbl eff_name) in
+      if not (List.mem fn_name existing) then
+        Hashtbl.replace effects_tbl eff_name (existing @ [fn_name])
+    in
+    List.iter (fun decl ->
+      match decl.Ast.decl_desc with
+      | Ast.DeclFn { fn_name; effects; _ } ->
+        let eff_names =
+          match List.assoc_opt fn_name ms.type_env with
+          | None -> []
+          | Some scheme ->
+            (match fn_effect_row scheme.Typechecker.body with
+             | Some row -> collect_row_effects row
+             | None -> effect_names_of_decl_annotation effects)
+        in
+        List.iter (fun eff -> add_fn_to_effect eff fn_name) eff_names
+      | _ -> ()
+    ) ms.typed_ast;
+    let effects_json = Hashtbl.fold (fun eff fn_names acc ->
+        (eff, Array (List.map (fun n -> String n) fn_names)) :: acc
+      ) effects_tbl [] in
+    let sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) effects_json in
+    Object [("effects", Object sorted)]
+
 let handle_verify_unused state args =
   let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
   match Hashtbl.find_opt state.modules module_name with
@@ -422,7 +505,7 @@ let handle state msg =
   | "notifications/initialized" ->
     ()
   | "tools/list" ->
-    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema; tool_query_interface_schema; tool_verify_exhaustive_schema; tool_verify_effects_schema; tool_verify_unused_schema])]))
+    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema; tool_query_interface_schema; tool_verify_exhaustive_schema; tool_verify_effects_schema; tool_verify_unused_schema; tool_query_effects_schema])]))
   | "tools/call" ->
     let params    = obj_get "params" msg in
     let tool_name = match obj_get "name" params with String s -> s | _ -> "" in
@@ -472,6 +555,13 @@ let handle state msg =
        ]))
      | "verify_unused" ->
        let result = handle_verify_unused state args in
+       send (response id (Object [
+         ("content", Array [
+           Object [("type", String "text"); ("text", String (json_to_string result))]
+         ])
+       ]))
+     | "query_effects" ->
+       let result = handle_query_effects state args in
        send (response id (Object [
          ("content", Array [
            Object [("type", String "text"); ("text", String (json_to_string result))]

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -731,6 +731,133 @@ let test_verify_unused_module_not_found () =
       (match err with `String s -> String.length s > 0 | _ -> false)
   )
 
+let query_effects_call id module_name =
+  Printf.sprintf
+    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_effects","arguments":{"module_name":"%s"}}}|}
+    id (json_string_escape module_name)
+
+(* Pure module — no effects at all. *)
+let pure_module_source =
+  {|fn add_one(x: Int) -> Int ! pure { add(x, 1) }
+fn double(x: Int) -> Int ! pure { add(x, x) }|}
+
+(* Module with one effectful function. *)
+let single_effect_source =
+  {|effect Log { log: (String) -> Unit }
+fn greet(msg: String) -> Unit ! {Log} { perform Log.log(msg) }
+fn pure_fn(x: Int) -> Int ! pure { x }|}
+
+(* Module where one function performs two effects, another performs one. *)
+let multi_effect_source =
+  {|effect Log { log: (String) -> Unit }
+effect Throw { throw: (String) -> Unit }
+fn do_both(x: Int) -> Unit ! {Log, Throw} { perform Log.log("hi") }
+fn do_log(x: Int) -> Unit ! {Log} { perform Log.log("x") }|}
+
+let test_query_effects_in_tools_list () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
+    let line = read_line () in
+    let json = mini_parse line in
+    let result = json_field "result" json in
+    let tools = json_field "tools" result in
+    let names = match tools with
+      | `List items ->
+        List.filter_map (fun item ->
+          match json_field "name" item with
+          | `String s -> Some s
+          | _ -> None) items
+      | _ -> []
+    in
+    Alcotest.(check bool) "query_effects in tools/list" true
+      (List.mem "query_effects" names)
+  )
+
+let test_query_effects_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (query_effects_call 2 "nonexistent");
+    let result = parse_response (read_line ()) in
+    let ok = json_field "ok" result in
+    Alcotest.(check bool) "ok is false" true
+      (match ok with `Bool false -> true | _ -> false);
+    let err = json_field "error" result in
+    Alcotest.(check bool) "error is non-empty string" true
+      (match err with `String s -> String.length s > 0 | _ -> false)
+  )
+
+let test_query_effects_pure_module () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 pure_module_source "mymod");
+    ignore (read_line ());
+    write_line (query_effects_call 3 "mymod");
+    let result = parse_response (read_line ()) in
+    let effects = json_field "effects" result in
+    Alcotest.(check bool) "effects is empty object" true
+      (match effects with `Assoc [] -> true | _ -> false)
+  )
+
+let test_query_effects_single_effect () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 single_effect_source "mymod");
+    ignore (read_line ());
+    write_line (query_effects_call 3 "mymod");
+    let result = parse_response (read_line ()) in
+    let effects = json_field "effects" result in
+    let log_fns = match effects with
+      | `Assoc fields -> (match List.assoc_opt "Log" fields with Some v -> v | None -> `Null)
+      | _ -> `Null
+    in
+    Alcotest.(check bool) "Log effect maps to greet" true
+      (match log_fns with
+       | `List fns -> List.exists (fun f -> f = `String "greet") fns
+       | _ -> false);
+    Alcotest.(check bool) "pure_fn not in Log's list" true
+      (match log_fns with
+       | `List fns -> not (List.exists (fun f -> f = `String "pure_fn") fns)
+       | _ -> false)
+  )
+
+let test_query_effects_multi_effect () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (submit_module_call 2 multi_effect_source "mymod");
+    ignore (read_line ());
+    write_line (query_effects_call 3 "mymod");
+    let result = parse_response (read_line ()) in
+    let effects = json_field "effects" result in
+    let get_fns eff_name = match effects with
+      | `Assoc fields -> (match List.assoc_opt eff_name fields with Some v -> v | None -> `Null)
+      | _ -> `Null
+    in
+    let log_fns = get_fns "Log" in
+    let throw_fns = get_fns "Throw" in
+    Alcotest.(check bool) "do_both appears under Log" true
+      (match log_fns with
+       | `List fns -> List.exists (fun f -> f = `String "do_both") fns
+       | _ -> false);
+    Alcotest.(check bool) "do_log appears under Log" true
+      (match log_fns with
+       | `List fns -> List.exists (fun f -> f = `String "do_log") fns
+       | _ -> false);
+    Alcotest.(check bool) "do_both appears under Throw" true
+      (match throw_fns with
+       | `List fns -> List.exists (fun f -> f = `String "do_both") fns
+       | _ -> false);
+    Alcotest.(check bool) "do_log does not appear under Throw" true
+      (match throw_fns with
+       | `List fns -> not (List.exists (fun f -> f = `String "do_log") fns)
+       | _ -> false)
+  )
+
 let () =
   ignore well_typed_source;
   ignore ill_typed_source;
@@ -773,5 +900,12 @@ let () =
       Alcotest.test_case "mutual recursion reachable from main — no unused"             `Quick test_verify_unused_mutual_recursion_both_reachable;
       Alcotest.test_case "mutual recursion unreachable from roots — both flagged"       `Quick test_verify_unused_mutual_recursion_both_unreachable;
       Alcotest.test_case "returns error when module not found"                           `Quick test_verify_unused_module_not_found;
+    ]);
+    ("query_effects", [
+      Alcotest.test_case "appears in tools/list"                                         `Quick test_query_effects_in_tools_list;
+      Alcotest.test_case "returns error when module not found"                           `Quick test_query_effects_module_not_found;
+      Alcotest.test_case "returns empty effects map for pure module"                     `Quick test_query_effects_pure_module;
+      Alcotest.test_case "maps single effect to performing function"                     `Quick test_query_effects_single_effect;
+      Alcotest.test_case "function with multiple effects appears under each"             `Quick test_query_effects_multi_effect;
     ]);
   ]


### PR DESCRIPTION
## Summary

- Registers a new `query_effects` tool in the MCP server that accepts `{ module_name: string }` and returns `{ "effects": { "EffectName": ["fn_a", "fn_b"], ... } }`
- Walks each top-level `DeclFn` in the submitted module's typed AST, extracts the effect row from the innermost `TyFun` arrow in the function's type scheme, and builds the effect → [function] map
- Functions with a pure or unresolved open row are omitted from the map; a fully pure module returns an empty `effects` object
- For zero-parameter functions (whose scheme body is not a `TyFun`), falls back to the declared effect annotation on the `DeclFn` node

## Test plan

- [x] `appears in tools/list` — `query_effects` is advertised via `tools/list`
- [x] `returns error when module not found` — error response for unsubmitted module name
- [x] `returns empty effects map for pure module` — all-pure functions produce `{ "effects": {} }`
- [x] `maps single effect to performing function` — effectful function appears under its effect; pure sibling does not
- [x] `function with multiple effects appears under each` — a function declaring two effects appears in both lists; a single-effect function only appears in its own list

Closes #70

https://claude.ai/code/session_01Ei9j1MJ8dwA5BnKMat8zjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei9j1MJ8dwA5BnKMat8zjx)_