### PR TITLE
Implement MCP batch protocol with unified diagnostic schema

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -6,4 +6,4 @@
 (executable
  (name mcp_server)
  (modules mcp_server)
- (libraries axiom_lib unix))
+ (libraries axiom_lib mcp_lib unix))

--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -1,19 +1,20 @@
 open Axiom_lib
+open Mcp_lib
 
-(* Minimal JSON type *)
+(* ─── Minimal JSON type ──────────────────────────────────────────────────── *)
 type json =
   | Null
-  | Bool of bool
-  | Int of int
+  | Bool   of bool
+  | Int    of int
   | String of string
-  | Array of json list
+  | Array  of json list
   | Object of (string * json) list
 
-(* JSON serializer *)
+(* ─── JSON serializer ────────────────────────────────────────────────────── *)
 let rec json_to_string = function
-  | Null -> "null"
+  | Null   -> "null"
   | Bool b -> if b then "true" else "false"
-  | Int n -> string_of_int n
+  | Int  n -> string_of_int n
   | String s ->
     let buf = Buffer.create (String.length s + 2) in
     Buffer.add_char buf '"';
@@ -32,7 +33,7 @@ let rec json_to_string = function
     "{" ^ String.concat "," (List.map (fun (k, v) ->
       json_to_string (String k) ^ ":" ^ json_to_string v) fields) ^ "}"
 
-(* Minimal recursive-descent JSON parser *)
+(* ─── JSON parser ────────────────────────────────────────────────────────── *)
 exception Json_error of string
 
 let parse_json s =
@@ -66,7 +67,6 @@ let parse_json s =
          | 'b'  -> Buffer.add_char buf '\b'
          | 'f'  -> Buffer.add_char buf '\012'
          | 'u'  ->
-           (* skip 4 hex digits; replace with '?' for simplicity *)
            for _ = 1 to 4 do ignore (next ()) done;
            Buffer.add_char buf '?'
          | c    -> raise (Json_error (Printf.sprintf "bad escape \\%c" c)));
@@ -145,7 +145,7 @@ let obj_get key = function
   | Object fields -> (match List.assoc_opt key fields with Some v -> v | None -> Null)
   | _ -> Null
 
-(* JSON-RPC output helpers *)
+(* ─── JSON-RPC helpers ───────────────────────────────────────────────────── *)
 let send json =
   print_string (json_to_string json);
   print_char '\n';
@@ -169,11 +169,15 @@ let bytes_to_hex b =
   done;
   Buffer.contents buf
 
-(* Per-module state stored after a successful submit_module call *)
+(* ─── Server state ───────────────────────────────────────────────────────── *)
+
+(* Per-module state stored after a successful write/submit_module command. *)
 type module_state = {
-  typed_ast  : Ast.program;
-  type_env   : Typechecker.env;
-  effect_env : Typechecker.effect_env;
+  typed_ast   : Ast.program;
+  type_env    : Typechecker.env;
+  effect_env  : Typechecker.effect_env;
+  root_hash   : string;  (* hex-encoded BLAKE3 hash of the program root node *)
+  decl_hashes : (string, string) Hashtbl.t;  (* decl name → hex hash *)
 }
 
 type state = {
@@ -182,213 +186,93 @@ type state = {
   node_store          : Node_store.t;
 }
 
-let format_type_error msg =
-  Object [("message", String msg); ("line", Int 0); ("col", Int 0)]
+(* ─── Diagnostic → JSON ──────────────────────────────────────────────────── *)
 
-let tool_submit_module_schema =
+let json_of_severity = function
+  | Mcp_types.Sev_error   -> String "error"
+  | Mcp_types.Sev_warning -> String "warning"
+  | Mcp_types.Sev_info    -> String "info"
+
+let json_of_location (loc : Mcp_types.location) =
+  let fields = [("line", Int loc.loc_line); ("col", Int loc.loc_col)] in
+  let fields = match loc.loc_module with
+    | None   -> fields
+    | Some m -> ("module", String m) :: fields
+  in
+  Object fields
+
+let json_of_related (r : Mcp_types.related_ref) =
+  let fields = [("message", String r.ref_message)] in
+  let fields = match r.ref_node with
+    | None   -> fields
+    | Some h -> ("node", String h) :: fields
+  in
+  Object fields
+
+let json_of_diagnostic (d : Mcp_types.diagnostic) =
   Object [
-    ("name", String "submit_module");
-    ("description", String "Parse, typecheck, and store a working-form Axiom module");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("source",      Object [("type", String "string")]);
-        ("module_name", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "source"; String "module_name"]);
-    ]);
+    ("severity", json_of_severity d.diag_severity);
+    ("code",     String d.diag_code);
+    ("message",  String d.diag_message);
+    ("node",     (match d.diag_node with None -> Null | Some h -> String h));
+    ("location", (match d.diag_location with None -> Null | Some l -> json_of_location l));
+    ("related",  Array (List.map json_of_related d.diag_related));
   ]
 
-let tool_verify_types_schema =
+(* ─── Batch response ─────────────────────────────────────────────────────── *)
+
+(* All four tool handlers share this single response shape, enforced by type. *)
+type batch_response = {
+  br_results     : json list;
+  br_stopped_at  : int option;
+  br_diagnostics : Mcp_types.diagnostic list;
+}
+
+let json_of_batch_response br =
   Object [
-    ("name", String "verify_types");
-    ("description", String "Typecheck a working-form Axiom module and return any type errors; does not update server state");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("source", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "source"]);
-    ]);
+    ("results",     Array br.br_results);
+    ("stopped_at",  (match br.br_stopped_at with None -> Null | Some i -> Int i));
+    ("diagnostics", Array (List.map json_of_diagnostic br.br_diagnostics));
   ]
 
-let tool_query_signature_schema =
-  Object [
-    ("name", String "query_signature");
-    ("description", String "Return the type and effect signature of a named function from a previously submitted module");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("module_name",   Object [("type", String "string")]);
-        ("function_name", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "module_name"; String "function_name"]);
-    ]);
-  ]
+(* ─── Command outcome ────────────────────────────────────────────────────── *)
 
-let tool_query_interface_schema =
-  Object [
-    ("name", String "query_interface");
-    ("description", String "Return the public API of a previously submitted module: pub type aliases, pub effect declarations, and pub function signatures");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("module_name", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "module_name"]);
-    ]);
-  ]
+(* Unrecoverable failures halt the batch at the current index.
+   Recoverable diagnostics (e.g. type/effect warnings) accumulate and allow
+   subsequent commands to continue. *)
+type cmd_outcome =
+  | Cmd_success of json * Mcp_types.diagnostic list
+  | Cmd_halt    of Mcp_types.diagnostic
 
-let tool_verify_exhaustive_schema =
-  Object [
-    ("name", String "verify_exhaustive");
-    ("description", String "Check every match expression in a previously submitted module for non-exhaustive patterns; returns warnings with missing constructor names");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("module_name", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "module_name"]);
-    ]);
-  ]
+(* ─── Batch executor ─────────────────────────────────────────────────────── *)
 
-let tool_verify_effects_schema =
-  Object [
-    ("name", String "verify_effects");
-    ("description", String "Check that every effect performed on any reachable call path from an entry-point function is handled before reaching the entry point's boundary; returns unhandled effect entries with effect name and call-site location");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("module_name",  Object [("type", String "string")]);
-        ("entry_point",  Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "module_name"; String "entry_point"]);
-    ]);
-  ]
+let batch_execute (dispatch : json -> cmd_outcome) (cmds : json list) : batch_response =
+  let results    = ref [] in
+  let diags      = ref [] in
+  let stopped_at = ref None in
+  let i          = ref 0 in
+  let go         = ref true in
+  let arr        = Array.of_list cmds in
+  let n          = Array.length arr in
+  while !go && !i < n do
+    (match dispatch arr.(!i) with
+     | Cmd_success (result, ds) ->
+       results := !results @ [result];
+       diags   := !diags @ ds;
+       incr i
+     | Cmd_halt d ->
+       diags      := !diags @ [d];
+       stopped_at := Some !i;
+       go         := false)
+  done;
+  { br_results = !results; br_stopped_at = !stopped_at; br_diagnostics = !diags }
 
-let tool_verify_unused_schema =
-  Object [
-    ("name", String "verify_unused");
-    ("description", String "Find declared but unreferenced functions, types, and imports in a previously submitted module; pub declarations and main are never flagged");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("module_name", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "module_name"]);
-    ]);
-  ]
+let get_commands args =
+  match obj_get "commands" args with
+  | Array cmds -> cmds
+  | _          -> []
 
-let handle_submit_module state args =
-  let source      = match obj_get "source"      args with String s -> s | _ -> "" in
-  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
-  try
-    let tokens   = Lexer.tokenize source in
-    let ast      = Parser.parse_program tokens in
-    let (type_env, effect_env) = Typechecker.check_program ast in
-    let enc      = Node_store.as_encoding_store state.node_store in
-    let root     = Node_encoding.encode_program enc ast in
-    let hash_hex = bytes_to_hex root in
-    Hashtbl.replace state.modules module_name { typed_ast = ast; type_env; effect_env };
-    Object [("ok", Bool true); ("hash", String hash_hex)]
-  with Failure msg ->
-    Object [("ok", Bool false); ("error", format_type_error msg)]
-
-let handle_verify_types args =
-  let source = match obj_get "source" args with String s -> s | _ -> "" in
-  try
-    let tokens = Lexer.tokenize source in
-    let ast    = Parser.parse_program tokens in
-    ignore (Typechecker.check_program ast);
-    Object [("errors", Array [])]
-  with Failure msg ->
-    Object [("errors", Array [format_type_error msg])]
-
-let handle_query_signature state args =
-  let module_name   = match obj_get "module_name"   args with String s -> s | _ -> "" in
-  let function_name = match obj_get "function_name" args with String s -> s | _ -> "" in
-  match Hashtbl.find_opt state.modules module_name with
-  | None ->
-    Object [("ok", Bool false);
-            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
-  | Some ms ->
-    match List.assoc_opt function_name ms.type_env with
-    | None ->
-      Object [("ok", Bool false);
-              ("error", String (Printf.sprintf "Function '%s' not found in module '%s'" function_name module_name))]
-    | Some scheme ->
-      let sig_str = Format.asprintf "%a" Typechecker.pp_ty scheme.body in
-      Object [("ok", Bool true); ("signature", String sig_str)]
-
-let render_interface_decl decl =
-  match decl.Ast.decl_desc with
-  | Ast.DeclFn { pub = true; fn_name; type_params; params; return_type; effects; _ } ->
-    let tp_s =
-      if type_params = [] then ""
-      else "<" ^ String.concat ", " type_params ^ ">"
-    in
-    let ann = match return_type, effects with
-      | Some ret, Some eff ->
-        " -> " ^ Printer.print_type_expr ret ^ " ! " ^ Printer.print_effect_set eff
-      | Some ret, None -> " -> " ^ Printer.print_type_expr ret
-      | _ -> ""
-    in
-    Some ("pub fn " ^ fn_name ^ tp_s ^ "(" ^
-          String.concat ", " (List.map Printer.print_param params) ^ ")" ^ ann)
-  | Ast.DeclType { pub = true; _ } ->
-    Some (Printer.print_decl decl)
-  | Ast.DeclEffect { pub = true; _ } ->
-    Some (Printer.print_decl decl)
-  | _ -> None
-
-let handle_verify_exhaustive state args =
-  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
-  match Hashtbl.find_opt state.modules module_name with
-  | None ->
-    Object [("ok", Bool false);
-            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
-  | Some ms ->
-    let warnings = Typechecker.collect_match_warnings ms.typed_ast in
-    let json_warnings = List.map (fun (w : Typechecker.match_warning) ->
-        Object [
-          ("location", Object [("line", Int w.mw_line); ("col", Int w.mw_col)]);
-          ("missing_patterns", Array (List.map (fun s -> String s) w.mw_missing));
-        ]) warnings in
-    Object [("warnings", Array json_warnings)]
-
-let handle_verify_effects state args =
-  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
-  let entry_point = match obj_get "entry_point" args with String s -> s | _ -> "" in
-  match Hashtbl.find_opt state.modules module_name with
-  | None ->
-    Object [("ok", Bool false);
-            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
-  | Some ms ->
-    (try
-       let sites = Typechecker.collect_unhandled_effects ms.typed_ast entry_point in
-       let json_sites = List.map (fun (s : Typechecker.effect_site) ->
-           Object [
-             ("effect", String s.es_effect);
-             ("site", Object [
-               ("function", String s.es_function);
-               ("line",     Int s.es_line);
-               ("col",      Int s.es_col);
-             ]);
-           ]) sites in
-       Object [("unhandled", Array json_sites)]
-     with Failure msg ->
-       Object [("ok", Bool false); ("error", String msg)])
-
-let handle_query_interface state args =
-  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
-  match Hashtbl.find_opt state.modules module_name with
-  | None ->
-    Object [("ok", Bool false);
-            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
-  | Some ms ->
-    let lines = List.filter_map render_interface_decl ms.typed_ast in
-    let iface = String.concat "\n" lines in
-    Object [("interface", String iface)]
+(* ─── Type pretty-printing helpers (carried over from old implementation) ── *)
 
 let rec ty_deref = function
   | Typechecker.TyMeta { Typechecker.inst = Some t; _ } -> ty_deref t
@@ -401,132 +285,377 @@ let rec row_deref = function
 let collect_row_effects row =
   let rec go acc r =
     match row_deref r with
-    | Typechecker.RPure -> List.rev acc
-    | Typechecker.RCons (e, rest) -> go (e.Typechecker.eff_name :: acc) rest
-    | Typechecker.RMeta _ -> List.rev acc
+    | Typechecker.RPure         -> List.rev acc
+    | Typechecker.RCons (e, tl) -> go (e.Typechecker.eff_name :: acc) tl
+    | Typechecker.RMeta _       -> List.rev acc
   in
   go [] row
 
-(* Walk a (possibly curried) function type to find the innermost arrow's effect
-   row, which is where fn_scheme_of_decl places the declared effects. Returns
-   None for 0-parameter functions whose scheme body is not a TyFun. *)
 let rec fn_effect_row ty =
   match ty_deref ty with
   | Typechecker.TyForall (_, t) -> fn_effect_row t
   | Typechecker.TyFun (_, ret, row) ->
     (match ty_deref ret with
      | Typechecker.TyFun _ as inner -> fn_effect_row inner
-     | _ -> Some row)
+     | _                            -> Some row)
   | _ -> None
 
 let effect_names_of_decl_annotation = function
   | None | Some Ast.Pure -> []
   | Some (Ast.Effects (ts, _)) ->
     List.filter_map (function
-      | Ast.TyName n -> Some n
-      | Ast.TyApp (n, _) -> Some n
-      | _ -> None) ts
+      | Ast.TyName n      -> Some n
+      | Ast.TyApp (n, _)  -> Some n
+      | _                 -> None) ts
 
-let tool_query_effects_schema =
-  Object [
-    ("name", String "query_effects");
-    ("description", String "Return a map from each effect name to the list of top-level functions that perform it in a previously submitted module");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("module_name", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "module_name"]);
-    ]);
-  ]
+(* ─── Public-interface rendering ─────────────────────────────────────────── *)
 
-let tool_query_callers_schema =
-  Object [
-    ("name", String "query_callers");
-    ("description", String "List all direct call sites of a named function within a previously submitted module; returns the containing function name and source location for each call");
-    ("inputSchema", Object [
-      ("type", String "object");
-      ("properties", Object [
-        ("module_name",   Object [("type", String "string")]);
-        ("function_name", Object [("type", String "string")]);
-      ]);
-      ("required", Array [String "module_name"; String "function_name"]);
-    ]);
-  ]
-
-let handle_query_effects state args =
-  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
-  match Hashtbl.find_opt state.modules module_name with
-  | None ->
-    Object [("ok", Bool false);
-            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
-  | Some ms ->
-    let effects_tbl : (string, string list) Hashtbl.t = Hashtbl.create 8 in
-    let add_fn_to_effect eff_name fn_name =
-      let existing = Option.value ~default:[] (Hashtbl.find_opt effects_tbl eff_name) in
-      if not (List.mem fn_name existing) then
-        Hashtbl.replace effects_tbl eff_name (existing @ [fn_name])
+let render_interface_decl decl =
+  match decl.Ast.decl_desc with
+  | Ast.DeclFn { pub = true; fn_name; type_params; params; return_type; effects; _ } ->
+    let tp_s =
+      if type_params = [] then ""
+      else "<" ^ String.concat ", " type_params ^ ">"
     in
-    List.iter (fun decl ->
-      match decl.Ast.decl_desc with
-      | Ast.DeclFn { fn_name; effects; _ } ->
-        let eff_names =
-          match List.assoc_opt fn_name ms.type_env with
-          | None -> []
-          | Some scheme ->
-            (match fn_effect_row scheme.Typechecker.body with
-             | Some row -> collect_row_effects row
-             | None -> effect_names_of_decl_annotation effects)
-        in
-        List.iter (fun eff -> add_fn_to_effect eff fn_name) eff_names
-      | _ -> ()
-    ) ms.typed_ast;
-    let effects_json = Hashtbl.fold (fun eff fn_names acc ->
-        (eff, Array (List.map (fun n -> String n) fn_names)) :: acc
-      ) effects_tbl [] in
-    let sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) effects_json in
-    Object [("effects", Object sorted)]
+    let ann = match return_type, effects with
+      | Some ret, Some eff ->
+        " -> " ^ Printer.print_type_expr ret ^ " ! " ^ Printer.print_effect_set eff
+      | Some ret, None -> " -> " ^ Printer.print_type_expr ret
+      | _              -> ""
+    in
+    Some ("pub fn " ^ fn_name ^ tp_s ^ "(" ^
+          String.concat ", " (List.map Printer.print_param params) ^ ")" ^ ann)
+  | Ast.DeclType   { pub = true; _ } -> Some (Printer.print_decl decl)
+  | Ast.DeclEffect { pub = true; _ } -> Some (Printer.print_decl decl)
+  | _ -> None
 
-let handle_verify_unused state args =
-  let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
-  match Hashtbl.find_opt state.modules module_name with
-  | None ->
-    Object [("ok", Bool false);
-            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
-  | Some ms ->
-    let items = Typechecker.collect_unused ms.typed_ast in
-    let json_items = List.map (fun (u : Typechecker.unused_item) ->
-        Object [
-          ("name", String u.ui_name);
-          ("kind", String u.ui_kind);
-          ("line", Int u.ui_line);
-          ("col",  Int u.ui_col);
-        ]) items in
-    Object [("unused", Array json_items)]
+(* ─── Location helpers ───────────────────────────────────────────────────── *)
 
-let handle_query_callers state args =
-  let module_name   = match obj_get "module_name"   args with String s -> s | _ -> "" in
-  let function_name = match obj_get "function_name" args with String s -> s | _ -> "" in
-  match Hashtbl.find_opt state.modules module_name with
-  | None ->
-    Object [("ok", Bool false);
-            ("error", String (Printf.sprintf "Module '%s' not found" module_name))]
-  | Some ms ->
-    match Typechecker.collect_callers ms.typed_ast function_name with
-    | Error msg ->
-      Object [("ok", Bool false); ("error", String msg)]
-    | Ok sites ->
-      let json_sites = List.map (fun (s : Typechecker.caller_site) ->
-          Object [
-            ("caller", String s.cs_caller);
-            ("line",   Int s.cs_line);
-            ("col",    Int s.cs_col);
-          ]) sites in
-      Object [("callers", Array json_sites)]
+let make_loc ?module_name line col =
+  Mcp_types.{ loc_module = module_name; loc_line = line; loc_col = col }
+
+(* ─── Decl-name extraction (for hash look-up) ────────────────────────────── *)
+
+let decl_name decl =
+  match decl.Ast.decl_desc with
+  | Ast.DeclFn     { fn_name;     _ } -> Some fn_name
+  | Ast.DeclType   { type_name;   _ } -> Some type_name
+  | Ast.DeclEffect { effect_name; _ } -> Some effect_name
+  | Ast.DeclModule { module_name; _ } -> Some module_name
+  | _                                  -> None
+
+(* ─── Query tool ─────────────────────────────────────────────────────────── *)
+
+let dispatch_query state cmd =
+  let op   = match obj_get "op"   cmd with String s -> s | _ -> "" in
+  let args = obj_get "args" cmd in
+  match op with
+  | "signature" ->
+    let mod_name = match obj_get "module" args with String s -> s | _ -> "" in
+    let fn_name  = match obj_get "name"   args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules mod_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" mod_name))
+     | Some ms ->
+       match List.assoc_opt fn_name ms.type_env with
+       | None ->
+         Cmd_halt (Mcp_types.make_error "anchor/not-found"
+           (Printf.sprintf "Function '%s' not found in module '%s'" fn_name mod_name))
+       | Some scheme ->
+         let sig_str = Format.asprintf "%a" Typechecker.pp_ty scheme.Typechecker.body in
+         let node = Hashtbl.find_opt ms.decl_hashes fn_name in
+         Cmd_success (Object [("signature", String sig_str);
+                               ("node", match node with None -> Null | Some h -> String h)],
+                      []))
+
+  | "interface" ->
+    let mod_name = match obj_get "module" args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules mod_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" mod_name))
+     | Some ms ->
+       let lines = List.filter_map render_interface_decl ms.typed_ast in
+       Cmd_success (Object [("interface", String (String.concat "\n" lines));
+                             ("node", String ms.root_hash)],
+                    []))
+
+  | "effects" ->
+    let mod_name = match obj_get "module" args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules mod_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" mod_name))
+     | Some ms ->
+       let tbl : (string, string list) Hashtbl.t = Hashtbl.create 8 in
+       let add eff fn =
+         let xs = Option.value ~default:[] (Hashtbl.find_opt tbl eff) in
+         if not (List.mem fn xs) then Hashtbl.replace tbl eff (xs @ [fn])
+       in
+       List.iter (fun decl ->
+         match decl.Ast.decl_desc with
+         | Ast.DeclFn { fn_name; effects; _ } ->
+           let effs =
+             match List.assoc_opt fn_name ms.type_env with
+             | None        -> []
+             | Some scheme ->
+               (match fn_effect_row scheme.Typechecker.body with
+                | Some row -> collect_row_effects row
+                | None     -> effect_names_of_decl_annotation effects)
+           in
+           List.iter (fun e -> add e fn_name) effs
+         | _ -> ()
+       ) ms.typed_ast;
+       let sorted = List.sort (fun (a, _) (b, _) -> String.compare a b)
+           (Hashtbl.fold (fun e fns acc ->
+              (e, Array (List.map (fun n -> String n) fns)) :: acc) tbl []) in
+       Cmd_success (Object [("effects", Object sorted);
+                             ("node", String ms.root_hash)],
+                    []))
+
+  | "callers" ->
+    let mod_name = match obj_get "module" args with String s -> s | _ -> "" in
+    let fn_name  = match obj_get "name"   args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules mod_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" mod_name))
+     | Some ms ->
+       (match Typechecker.collect_callers ms.typed_ast fn_name with
+        | Error msg ->
+          Cmd_halt (Mcp_types.make_error "anchor/not-found" msg)
+        | Ok sites ->
+          let json_sites = List.map (fun (s : Typechecker.caller_site) ->
+              let node = Hashtbl.find_opt ms.decl_hashes s.cs_caller in
+              Object [
+                ("caller", String s.cs_caller);
+                ("line",   Int s.cs_line);
+                ("col",    Int s.cs_col);
+                ("node",   match node with None -> Null | Some h -> String h);
+              ]) sites in
+          Cmd_success (Object [("callers", Array json_sites)], [])))
+
+  | _ ->
+    Cmd_halt (Mcp_types.make_error "command/unknown"
+      (Printf.sprintf "Unknown query op '%s'" op))
+
+(* ─── Write tool ─────────────────────────────────────────────────────────── *)
+
+(* After storing a module, run all verify passes and collect diagnostics. *)
+let post_write_verify ms =
+  let diags = ref [] in
+  (* match exhaustiveness warnings *)
+  List.iter (fun (w : Typechecker.match_warning) ->
+    let msg = Printf.sprintf "Non-exhaustive match; missing: %s"
+        (String.concat ", " w.mw_missing) in
+    diags := !diags @ [Mcp_types.make_warning
+        ~node:ms.root_hash
+        ~location:(make_loc w.mw_line w.mw_col)
+        "match/non-exhaustive" msg]
+  ) (Typechecker.collect_match_warnings ms.typed_ast);
+  (* unused declarations *)
+  List.iter (fun (u : Typechecker.unused_item) ->
+    let node = Hashtbl.find_opt ms.decl_hashes u.ui_name in
+    let msg = Printf.sprintf "Unused %s '%s'" u.ui_kind u.ui_name in
+    diags := !diags @ [Mcp_types.make_warning
+        ?node
+        ~location:(make_loc u.ui_line u.ui_col)
+        "decl/unused" msg]
+  ) (Typechecker.collect_unused ms.typed_ast);
+  !diags
+
+let dispatch_write state cmd =
+  let op   = match obj_get "op"   cmd with String s -> s | _ -> "" in
+  let args = obj_get "args" cmd in
+  match op with
+  | "submit_module" ->
+    let source      = match obj_get "source"      args with String s -> s | _ -> "" in
+    let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
+    (try
+       let tokens    = Lexer.tokenize source in
+       let ast       = Parser.parse_program tokens in
+       let (type_env, effect_env) = Typechecker.check_program ast in
+       let enc       = Node_store.as_encoding_store state.node_store in
+       let root      = Node_encoding.encode_program enc ast in
+       let root_hash = bytes_to_hex root in
+       let enc2      = Node_store.as_encoding_store state.node_store in
+       let decl_hashes = Hashtbl.create 16 in
+       List.iter (fun decl ->
+         match decl_name decl with
+         | Some n ->
+           let h = Node_encoding.encode_decl enc2 decl in
+           Hashtbl.replace decl_hashes n (bytes_to_hex h)
+         | None -> ()
+       ) ast;
+       let ms = { typed_ast = ast; type_env; effect_env; root_hash; decl_hashes } in
+       Hashtbl.replace state.modules module_name ms;
+       let verify_diags = post_write_verify ms in
+       Cmd_success (Object [("hash", String root_hash)], verify_diags)
+     with Failure msg ->
+       Cmd_halt (Mcp_types.make_error "parse/error" msg))
+
+  | _ ->
+    Cmd_halt (Mcp_types.make_error "command/unknown"
+      (Printf.sprintf "Unknown write op '%s'" op))
+
+(* ─── Transform tool ─────────────────────────────────────────────────────── *)
+
+let dispatch_transform _state cmd =
+  let op = match obj_get "op" cmd with String s -> s | _ -> "" in
+  Cmd_halt (Mcp_types.make_error "command/unimplemented"
+    (Printf.sprintf "Transform op '%s' is not yet implemented" op))
+
+(* ─── Verify tool ────────────────────────────────────────────────────────── *)
+
+let dispatch_verify state cmd =
+  let op   = match obj_get "op"   cmd with String s -> s | _ -> "" in
+  let args = obj_get "args" cmd in
+  match op with
+  | "types" ->
+    let source = match obj_get "source" args with String s -> s | _ -> "" in
+    (try
+       let tokens = Lexer.tokenize source in
+       let ast    = Parser.parse_program tokens in
+       ignore (Typechecker.check_program ast);
+       Cmd_success (Object [], [])
+     with Failure msg ->
+       let diag = Mcp_types.make_error "type/error" msg in
+       Cmd_success (Object [], [diag]))
+
+  | "exhaustive" ->
+    let mod_name = match obj_get "module" args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules mod_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" mod_name))
+     | Some ms ->
+       let warnings = Typechecker.collect_match_warnings ms.typed_ast in
+       let diags = List.map (fun (w : Typechecker.match_warning) ->
+           let msg = Printf.sprintf "Non-exhaustive match; missing: %s"
+               (String.concat ", " w.mw_missing) in
+           Mcp_types.make_warning
+             ~node:ms.root_hash
+             ~location:(make_loc w.mw_line w.mw_col)
+             "match/non-exhaustive" msg
+         ) warnings in
+       Cmd_success (Object [], diags))
+
+  | "effects" ->
+    let mod_name   = match obj_get "module"      args with String s -> s | _ -> "" in
+    let entry_point = match obj_get "entry_point" args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules mod_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" mod_name))
+     | Some ms ->
+       (try
+          let sites = Typechecker.collect_unhandled_effects ms.typed_ast entry_point in
+          let diags = List.map (fun (s : Typechecker.effect_site) ->
+              let node = Hashtbl.find_opt ms.decl_hashes s.es_function in
+              let msg  = Printf.sprintf "Unhandled effect '%s' in function '%s'"
+                  s.es_effect s.es_function in
+              Mcp_types.make_warning ?node
+                ~location:(make_loc s.es_line s.es_col)
+                "effect/unhandled" msg
+            ) sites in
+          Cmd_success (Object [], diags)
+        with Failure msg ->
+          Cmd_halt (Mcp_types.make_error "anchor/not-found" msg)))
+
+  | "unused" ->
+    let mod_name = match obj_get "module" args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules mod_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" mod_name))
+     | Some ms ->
+       let items = Typechecker.collect_unused ms.typed_ast in
+       let diags = List.map (fun (u : Typechecker.unused_item) ->
+           let node = Hashtbl.find_opt ms.decl_hashes u.ui_name in
+           let msg  = Printf.sprintf "Unused %s '%s'" u.ui_kind u.ui_name in
+           Mcp_types.make_warning ?node
+             ~location:(make_loc u.ui_line u.ui_col)
+             "decl/unused" msg
+         ) items in
+       Cmd_success (Object [], diags))
+
+  | _ ->
+    Cmd_halt (Mcp_types.make_error "command/unknown"
+      (Printf.sprintf "Unknown verify op '%s'" op))
+
+(* ─── Tool schemas ───────────────────────────────────────────────────────── *)
+
+let command_schema ops =
+  Object [
+    ("type", String "array");
+    ("items", Object [
+       ("type", String "object");
+       ("properties", Object [
+          ("op",   Object [("type", String "string");
+                           ("enum", Array (List.map (fun s -> String s) ops))]);
+          ("args", Object [("type", String "object")]);
+        ]);
+       ("required", Array [String "op"; String "args"]);
+     ]);
+  ]
+
+let batch_input_schema ops =
+  Object [
+    ("type", String "object");
+    ("properties", Object [("commands", command_schema ops)]);
+    ("required", Array [String "commands"]);
+  ]
+
+let tool_query_schema =
+  Object [
+    ("name", String "query");
+    ("description", String
+       "Read the IR graph: function signatures, module interfaces, effect maps, \
+        and caller graphs.  Accepts a batch of commands executed in order.");
+    ("inputSchema", batch_input_schema ["signature"; "interface"; "effects"; "callers"]);
+  ]
+
+let tool_write_schema =
+  Object [
+    ("name", String "write");
+    ("description", String
+       "Submit working-form Axiom source; elaborate, typecheck, store, and \
+        automatically verify the resulting state.  Accepts a batch of commands.");
+    ("inputSchema", batch_input_schema ["submit_module"]);
+  ]
+
+let tool_transform_schema =
+  Object [
+    ("name", String "transform");
+    ("description", String
+       "Apply mechanical, deterministic refactors (rename, extract-function, \
+        mock-effects, add-effect-logging, inline-handler).  Automatically \
+        verifies the resulting state.  Accepts a batch of commands.");
+    ("inputSchema", batch_input_schema []);
+  ]
+
+let tool_verify_schema =
+  Object [
+    ("name", String "verify");
+    ("description", String
+       "On-demand invariant checks: types, exhaustive pattern matching, effect \
+        handling, and unused declarations.  Accepts a batch of commands.");
+    ("inputSchema", batch_input_schema ["types"; "exhaustive"; "effects"; "unused"]);
+  ]
+
+(* ─── Request handler ────────────────────────────────────────────────────── *)
+
+let wrap_batch_result br =
+  Object [
+    ("content", Array [
+       Object [("type", String "text");
+               ("text", String (json_to_string (json_of_batch_response br)))]])
+  ]
 
 let handle state msg =
-  let id     = obj_get "id" msg in
-  let meth   = match obj_get "method" msg with String s -> s | _ -> "" in
+  let id   = obj_get "id" msg in
+  let meth = match obj_get "method" msg with String s -> s | _ -> "" in
   Printf.eprintf "[mcp] method=%s\n%!" meth;
   match meth with
   | "initialize" ->
@@ -536,87 +665,45 @@ let handle state msg =
       ("serverInfo", Object [("name", String "axiom"); ("version", String "0.1.0")]);
       ("capabilities", Object [("tools", Object [])]);
     ]))
-  | "notifications/initialized" ->
-    ()
+
+  | "notifications/initialized" -> ()
+
   | "tools/list" ->
-    send (response id (Object [("tools", Array [tool_submit_module_schema; tool_verify_types_schema; tool_query_signature_schema; tool_query_interface_schema; tool_verify_exhaustive_schema; tool_verify_effects_schema; tool_verify_unused_schema; tool_query_effects_schema; tool_query_callers_schema])]))
+    send (response id (Object [
+      ("tools", Array [tool_query_schema; tool_write_schema;
+                       tool_transform_schema; tool_verify_schema])
+    ]))
+
   | "tools/call" ->
     let params    = obj_get "params" msg in
     let tool_name = match obj_get "name" params with String s -> s | _ -> "" in
     let args      = obj_get "arguments" params in
+    let cmds      = get_commands args in
     (match tool_name with
-     | "submit_module" ->
-       let result = handle_submit_module state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "verify_types" ->
-       let result = handle_verify_types args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "query_signature" ->
-       let result = handle_query_signature state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "query_interface" ->
-       let result = handle_query_interface state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "verify_exhaustive" ->
-       let result = handle_verify_exhaustive state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "verify_effects" ->
-       let result = handle_verify_effects state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "verify_unused" ->
-       let result = handle_verify_unused state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "query_effects" ->
-       let result = handle_query_effects state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
-     | "query_callers" ->
-       let result = handle_query_callers state args in
-       send (response id (Object [
-         ("content", Array [
-           Object [("type", String "text"); ("text", String (json_to_string result))]
-         ])
-       ]))
+     | "query" ->
+       send (response id (wrap_batch_result
+           (batch_execute (dispatch_query state) cmds)))
+     | "write" ->
+       send (response id (wrap_batch_result
+           (batch_execute (dispatch_write state) cmds)))
+     | "transform" ->
+       send (response id (wrap_batch_result
+           (batch_execute (dispatch_transform state) cmds)))
+     | "verify" ->
+       send (response id (wrap_batch_result
+           (batch_execute (dispatch_verify state) cmds)))
      | _ ->
        send (error_response id (-32601) ("Unknown tool: " ^ tool_name)))
+
   | _ ->
     (match id with
      | Null -> ()
-     | _ -> send (error_response id (-32601) ("Method not found: " ^ meth)))
+     | _    -> send (error_response id (-32601) ("Method not found: " ^ meth)))
+
+(* ─── Entry point ────────────────────────────────────────────────────────── *)
 
 let () =
-  let store_dir  =
+  let store_dir =
     let path = Filename.temp_file "axiom_mcp_" "_dir" in
     Sys.remove path;
     Unix.mkdir path 0o700;

--- a/docs/implementation/mcp.md
+++ b/docs/implementation/mcp.md
@@ -1,0 +1,218 @@
+# MCP Server — Batch Protocol and Diagnostic Schema
+
+This document describes the wire protocol and OCaml type structure for the
+Axiom MCP server (`bin/mcp_server.ml`).  It is the implementation reference
+for issue #83 and the foundational ground-work for issue #82.
+
+---
+
+## Tool surface
+
+The server exposes **exactly four tools**:
+
+| Tool        | Purpose |
+|-------------|---------|
+| `query`     | Read the IR graph: signatures, interfaces, effect maps, caller graphs. |
+| `write`     | Submit working-form source; elaborate, typecheck, store, and automatically verify. |
+| `transform` | Mechanical deterministic refactors (rename, extract-function, …). |
+| `verify`    | On-demand invariant checks: types, exhaustive patterns, effect handling, unused declarations. |
+
+---
+
+## Batch request schema
+
+Every tool accepts a single `arguments` object:
+
+```json
+{
+  "commands": [
+    { "op": "<string>", "args": { ... } },
+    ...
+  ]
+}
+```
+
+Commands execute in order within a single round-trip.
+
+### Valid ops per tool
+
+| Tool        | Valid `op` values |
+|-------------|-------------------|
+| `query`     | `"signature"`, `"interface"`, `"effects"`, `"callers"` |
+| `write`     | `"submit_module"` |
+| `transform` | *(none yet — stub)* |
+| `verify`    | `"types"`, `"exhaustive"`, `"effects"`, `"unused"` |
+
+### Command argument shapes
+
+**`query` ops**
+
+```json
+// signature — resolve a function's type
+{ "op": "signature", "args": { "module": "<name>", "name": "<fn-name>" } }
+
+// interface — public API of a stored module
+{ "op": "interface", "args": { "module": "<name>" } }
+
+// effects — map effect names → performing functions
+{ "op": "effects",   "args": { "module": "<name>" } }
+
+// callers — direct call sites of a function
+{ "op": "callers",   "args": { "module": "<name>", "name": "<fn-name>" } }
+```
+
+**`write` ops**
+
+```json
+// submit_module — parse, typecheck, store, and auto-verify
+{ "op": "submit_module", "args": { "source": "<axiom source>", "module_name": "<name>" } }
+```
+
+**`verify` ops**
+
+```json
+// types — typecheck source without storing state
+{ "op": "types",      "args": { "source": "<axiom source>" } }
+
+// exhaustive — non-exhaustive match checks on a stored module
+{ "op": "exhaustive", "args": { "module": "<name>" } }
+
+// effects — unhandled-effect checks from an entry point
+{ "op": "effects",    "args": { "module": "<name>", "entry_point": "<fn-name>" } }
+
+// unused — unreferenced private declarations in a stored module
+{ "op": "unused",     "args": { "module": "<name>" } }
+```
+
+---
+
+## Batch response schema
+
+```json
+{
+  "results":     [ <result-object>, ... ],
+  "stopped_at":  <int> | null,
+  "diagnostics": [ <diagnostic>, ... ]
+}
+```
+
+- `results[i]` corresponds positionally to `commands[i]`.
+- If execution halted at index *k* due to an **unrecoverable** failure,
+  `results` has length *k* (the failed command's result is omitted) and
+  `stopped_at` equals *k*.
+- `diagnostics` accumulates diagnostics from all executed commands.
+
+### Per-op result shapes
+
+| Op             | Result fields |
+|----------------|---------------|
+| `signature`    | `{ "signature": "<type string>", "node": "<hash>" }` |
+| `interface`    | `{ "interface": "<source text>", "node": "<hash>" }` |
+| `effects`      | `{ "effects": { "<EffectName>": ["<fn>", ...] }, "node": "<hash>" }` |
+| `callers`      | `{ "callers": [{ "caller": "...", "line": int, "col": int, "node": "<hash>" }] }` |
+| `submit_module`| `{ "hash": "<root-hash>" }` |
+| `types`        | `{}` (diagnostics carry the errors) |
+| `exhaustive`   | `{}` (diagnostics carry any warnings) |
+| `effects`      | `{}` (diagnostics carry any warnings) |
+| `unused`       | `{}` (diagnostics carry any warnings) |
+
+---
+
+## Diagnostic schema
+
+Every diagnostic produced by every tool shares one OCaml record type
+(`Mcp_lib.Mcp_types.diagnostic`), making per-tool divergence a compile error.
+
+```json
+{
+  "severity": "error" | "warning" | "info",
+  "code":     "<category/slug>",
+  "message":  "<human-readable text>",
+  "node":     "<blake3-hex>" | null,
+  "location": { "module": "<name>", "line": int, "col": int } | null,
+  "related":  [ { "node": "<hash>", "message": "<text>" }, ... ]
+}
+```
+
+### Field semantics
+
+| Field      | Semantics |
+|------------|-----------|
+| `severity` | `"error"` for failures, `"warning"` for style/safety issues, `"info"` for informational notes. |
+| `code`     | Slash-separated category and slug, e.g. `"type/error"`, `"effect/unhandled"`, `"match/non-exhaustive"`, `"decl/unused"`. |
+| `message`  | Free-form human-readable description. |
+| `node`     | BLAKE3 hex hash of the primary program element the diagnostic refers to.  **Required** whenever the diagnostic names a specific declaration or expression; `null` otherwise. |
+| `location` | Supplementary source location.  Optional; prefer `node` for stable chaining. |
+| `related`  | Secondary references, e.g. the conflicting declaration in a name-clash error. |
+
+### Code catalogue
+
+| Code                    | Severity | Halts batch? | Meaning |
+|-------------------------|----------|--------------|---------|
+| `anchor/not-found`      | error    | yes          | Named module or function does not exist in server state. |
+| `command/unknown`       | error    | yes          | The `op` field is not a recognised command for this tool. |
+| `command/unimplemented` | error    | yes          | The `op` is known but not yet implemented. |
+| `parse/error`           | error    | yes          | Source failed to lex or parse; the module was not stored. |
+| `type/error`            | error    | no           | Type-checking error (from `verify types`). |
+| `effect/unhandled`      | warning  | no           | An effect escapes an entry-point boundary. |
+| `match/non-exhaustive`  | warning  | no           | A `match` expression is missing one or more constructors. |
+| `decl/unused`           | warning  | no           | A private declaration is never referenced. |
+
+---
+
+## Failure semantics
+
+- **Unrecoverable** failures (halts the batch): malformed request structure,
+  unknown/unimplemented command op, anchor not found.
+- **Recoverable** diagnostics (batch continues): type errors from `verify
+  types`, unhandled effects, non-exhaustive matches, unused declarations.
+
+A `write submit_module` that fails to parse or typecheck is unrecoverable —
+the module is not stored and subsequent commands that reference it will also
+fail.  A successful `write` always runs all verify passes inline and surfaces
+any warnings as recoverable diagnostics in the same response.
+
+---
+
+## OCaml type structure
+
+The canonical types live in `lib/mcp/mcp_types.ml`:
+
+```ocaml
+type severity = Sev_error | Sev_warning | Sev_info
+
+type location = {
+  loc_module : string option;
+  loc_line   : int;
+  loc_col    : int;
+}
+
+type related_ref = {
+  ref_node    : string option;
+  ref_message : string;
+}
+
+type diagnostic = {
+  diag_severity : severity;
+  diag_code     : string;
+  diag_message  : string;
+  diag_node     : string option;
+  diag_location : location option;
+  diag_related  : related_ref list;
+}
+```
+
+`bin/mcp_server.ml` defines the local `batch_response` type:
+
+```ocaml
+type batch_response = {
+  br_results     : json list;
+  br_stopped_at  : int option;
+  br_diagnostics : Mcp_types.diagnostic list;
+}
+```
+
+All four tool handlers (`dispatch_query`, `dispatch_write`, `dispatch_transform`,
+`dispatch_verify`) return `cmd_outcome` values which the shared `batch_execute`
+function folds into a `batch_response`.  A handler that returns a different type
+will not compile.

--- a/lib/mcp/dune
+++ b/lib/mcp/dune
@@ -1,0 +1,3 @@
+(library
+ (name mcp_lib)
+ (modules mcp_types))

--- a/lib/mcp/mcp_types.ml
+++ b/lib/mcp/mcp_types.ml
@@ -1,0 +1,44 @@
+(* Unified envelope types for the MCP batch protocol (issue #83).
+   Every tool handler must return a batch_response; every diagnostic must be a
+   diagnostic record.  Using these shared OCaml types makes it a compile-time
+   error to diverge from the schema. *)
+
+type severity = Sev_error | Sev_warning | Sev_info
+
+(* Supplementary source location — content-addressed node hash is preferred. *)
+type location = {
+  loc_module : string option;
+  loc_line   : int;
+  loc_col    : int;
+}
+
+(* A secondary reference in a diagnostic (e.g. the "other" site in a conflict). *)
+type related_ref = {
+  ref_node    : string option;
+  ref_message : string;
+}
+
+(* Single diagnostic shared by all four tools.
+   [diag_node] is the primary content-addressed BLAKE3 anchor; it must be
+   populated whenever the diagnostic refers to a specific program element.
+   [diag_location] is supplementary and may be omitted. *)
+type diagnostic = {
+  diag_severity : severity;
+  diag_code     : string;
+  diag_message  : string;
+  diag_node     : string option;
+  diag_location : location option;
+  diag_related  : related_ref list;
+}
+
+let make_diagnostic sev ?node ?location ?(related = []) code message =
+  { diag_severity = sev;
+    diag_code = code;
+    diag_message = message;
+    diag_node = node;
+    diag_location = location;
+    diag_related = related }
+
+let make_error   = make_diagnostic Sev_error
+let make_warning = make_diagnostic Sev_warning
+let make_info    = make_diagnostic Sev_info

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -38,7 +38,8 @@ let start_server () =
   in
   (write_line, read_line, close)
 
-(* Minimal JSON accessor helpers *)
+(* ─── Minimal JSON parser ────────────────────────────────────────────────── *)
+
 let json_field key json =
   match json with
   | `Assoc fields -> (match List.assoc_opt key fields with Some v -> v | None -> `Null)
@@ -130,28 +131,7 @@ let mini_parse s =
   in
   parse_value ()
 
-let parse_response line =
-  let json = mini_parse line in
-  let result = json_field "result" json in
-  let content = json_field "content" result in
-  (match content with
-   | `List (item :: _) ->
-     let text = json_field "text" item in
-     (match text with `String s -> mini_parse s | _ -> `Null)
-   | _ -> result)
-
-let initialize write_line read_line =
-  write_line {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}|};
-  ignore (read_line ());
-  write_line {|{"jsonrpc":"2.0","id":null,"method":"notifications/initialized","params":{}}|}
-
-let well_typed_source = {|fn double(x: Int) -> Int ! pure { add(x, x) }|}
-
-let ill_typed_source = {|fn go() -> Unit ! pure { perform Nope.boom() }|}
-
-(* ------------------------------------------------------------------ *)
-(* Tests                                                               *)
-(* ------------------------------------------------------------------ *)
+(* ─── Protocol helpers ───────────────────────────────────────────────────── *)
 
 let json_string_escape s =
   let buf = Buffer.create (String.length s + 2) in
@@ -164,252 +144,60 @@ let json_string_escape s =
     | c    -> Buffer.add_char buf c) s;
   Buffer.contents buf
 
-let verify_types_call id src =
+let initialize write_line read_line =
+  write_line {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}|};
+  ignore (read_line ());
+  write_line {|{"jsonrpc":"2.0","id":null,"method":"notifications/initialized","params":{}}|}
+
+(* Build a tools/call JSON-RPC request.
+   [commands_json] is a pre-serialised JSON array string. *)
+let tool_call id tool_name commands_json =
   Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"verify_types","arguments":{"source":"%s"}}}|}
-    id (json_string_escape src)
+    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"%s","arguments":{"commands":%s}}}|}
+    id tool_name commands_json
 
-let submit_module_call id src name =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"submit_module","arguments":{"source":"%s","module_name":"%s"}}}|}
-    id (json_string_escape src) (json_string_escape name)
+(* Build a single-command batch array. [args_json] is a pre-serialised object. *)
+let single_cmd op args_json =
+  Printf.sprintf {|[{"op":"%s","args":%s}]|} op args_json
 
-let query_signature_call id module_name function_name =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_signature","arguments":{"module_name":"%s","function_name":"%s"}}}|}
-    id (json_string_escape module_name) (json_string_escape function_name)
+(* Parse the batch_response JSON from a raw server line. *)
+let parse_batch_response line =
+  let json = mini_parse line in
+  let result = json_field "result" json in
+  let content = json_field "content" result in
+  match content with
+  | `List (item :: _) ->
+    let text = json_field "text" item in
+    (match text with `String s -> mini_parse s | _ -> `Null)
+  | _ -> result
 
-let query_interface_call id module_name =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_interface","arguments":{"module_name":"%s"}}}|}
-    id (json_string_escape module_name)
+(* First element of the "results" array, or `Null. *)
+let first_result batch =
+  match json_field "results" batch with
+  | `List (r :: _) -> r
+  | _              -> `Null
 
-let test_verify_types_well_typed () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (verify_types_call 2 well_typed_source);
-    let result = parse_response (read_line ()) in
-    let errors = json_field "errors" result in
-    Alcotest.(check bool) "errors is empty list" true
-      (match errors with `List [] -> true | _ -> false)
-  )
+(* "diagnostics" array, or []. *)
+let batch_diagnostics batch =
+  match json_field "diagnostics" batch with
+  | `List ds -> ds
+  | _        -> []
 
-let test_verify_types_type_error () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (verify_types_call 2 ill_typed_source);
-    let result = parse_response (read_line ()) in
-    let errors = json_field "errors" result in
-    Alcotest.(check bool) "errors is non-empty" true
-      (match errors with `List (_ :: _) -> true | _ -> false);
-    (match errors with
-     | `List (err :: _) ->
-       let msg = json_field "message" err in
-       Alcotest.(check bool) "error has message field" true
-         (match msg with `String s -> String.length s > 0 | _ -> false);
-       let line = json_field "line" err in
-       Alcotest.(check bool) "error has line field" true
-         (match line with `Int _ -> true | _ -> false);
-       let col = json_field "col" err in
-       Alcotest.(check bool) "error has col field" true
-         (match col with `Int _ -> true | _ -> false)
-     | _ -> ())
-  )
+(* True when the batch completed without halting. *)
+let batch_ok batch =
+  match json_field "stopped_at" batch with
+  | `Null -> true
+  | _     -> false
 
-let test_verify_types_does_not_update_state () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (verify_types_call 2 ill_typed_source);
-    ignore (read_line ());
-    write_line (submit_module_call 3 well_typed_source "test");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "submit_module still succeeds after verify_types" true
-      (match ok with `Bool true -> true | _ -> false)
-  )
+(* ─── Shared test sources ────────────────────────────────────────────────── *)
 
-let test_tools_list_includes_verify_types () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
-    let line = read_line () in
-    let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
-    let names = match tools with
-      | `List items ->
-        List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
-      | _ -> []
-    in
-    Alcotest.(check bool) "verify_types in tools/list" true
-      (List.mem "verify_types" names)
-  )
-
-let test_query_signature_success () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 well_typed_source "mymod");
-    ignore (read_line ());
-    write_line (query_signature_call 3 "mymod" "double");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is true" true
-      (match ok with `Bool true -> true | _ -> false);
-    let sig_ = json_field "signature" result in
-    Alcotest.(check bool) "signature is a non-empty string" true
-      (match sig_ with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let test_query_signature_module_not_found () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (query_signature_call 2 "nonexistent" "double");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error message is a non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let test_query_signature_function_not_found () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 well_typed_source "mymod");
-    ignore (read_line ());
-    write_line (query_signature_call 3 "mymod" "nonexistent_fn");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error message is a non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let test_query_signature_in_tools_list () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
-    let line = read_line () in
-    let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
-    let names = match tools with
-      | `List items ->
-        List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
-      | _ -> []
-    in
-    Alcotest.(check bool) "query_signature in tools/list" true
-      (List.mem "query_signature" names)
-  )
+let well_typed_source = {|fn double(x: Int) -> Int ! pure { add(x, x) }|}
+let ill_typed_source   = {|fn go() -> Unit ! pure { perform Nope.boom() }|}
 
 let mixed_visibility_source =
   {|pub fn add_one(x: Int) -> Int ! pure { add(x, 1) }
 fn internal_helper(x: Int) -> Int ! pure { x }
 pub type Color = | Red | Green | Blue|}
-
-let contains_substring haystack needle =
-  let hlen = String.length haystack and nlen = String.length needle in
-  if nlen = 0 then true
-  else if nlen > hlen then false
-  else
-    let found = ref false in
-    for i = 0 to hlen - nlen do
-      if not !found &&
-         String.sub haystack i nlen = needle then
-        found := true
-    done;
-    !found
-
-let test_query_interface_returns_only_pub () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 mixed_visibility_source "mymod");
-    ignore (read_line ());
-    write_line (query_interface_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let iface = json_field "interface" result in
-    let iface_str = match iface with `String s -> s | _ -> "" in
-    Alcotest.(check bool) "interface contains pub fn" true
-      (contains_substring iface_str "pub fn add_one");
-    Alcotest.(check bool) "interface contains pub type" true
-      (contains_substring iface_str "pub type Color");
-    Alcotest.(check bool) "interface excludes private fn" true
-      (not (contains_substring iface_str "internal_helper"))
-  )
-
-let test_query_interface_fn_has_no_body () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 mixed_visibility_source "mymod");
-    ignore (read_line ());
-    write_line (query_interface_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let iface = json_field "interface" result in
-    let iface_str = match iface with `String s -> s | _ -> "" in
-    Alcotest.(check bool) "interface is a non-empty string" true
-      (String.length iface_str > 0);
-    Alcotest.(check bool) "interface has no fn body braces" true
-      (not (String.contains iface_str '{'))
-  )
-
-let test_query_interface_module_not_found () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (query_interface_call 2 "nonexistent");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let test_query_interface_in_tools_list () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
-    let line = read_line () in
-    let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
-    let names = match tools with
-      | `List items ->
-        List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
-      | _ -> []
-    in
-    Alcotest.(check bool) "query_interface in tools/list" true
-      (List.mem "query_interface" names)
-  )
-
-let verify_exhaustive_call id module_name =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"verify_exhaustive","arguments":{"module_name":"%s"}}}|}
-    id (json_string_escape module_name)
 
 let exhaustive_source =
   {|type Color = | Red | Green | Blue
@@ -421,60 +209,6 @@ fn describe(c: Color) -> Int ! pure {
   }
 }|}
 
-let test_verify_exhaustive_in_tools_list () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
-    let line = read_line () in
-    let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
-    let names = match tools with
-      | `List items ->
-        List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
-      | _ -> []
-    in
-    Alcotest.(check bool) "verify_exhaustive in tools/list" true
-      (List.mem "verify_exhaustive" names)
-  )
-
-let test_verify_exhaustive_exhaustive_module () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 exhaustive_source "mymod");
-    ignore (read_line ());
-    write_line (verify_exhaustive_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let warnings = json_field "warnings" result in
-    Alcotest.(check bool) "warnings is empty list" true
-      (match warnings with `List [] -> true | _ -> false)
-  )
-
-let test_verify_exhaustive_module_not_found () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (verify_exhaustive_call 2 "nonexistent");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let verify_effects_call id module_name entry_point =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"verify_effects","arguments":{"module_name":"%s","entry_point":"%s"}}}|}
-    id (json_string_escape module_name) (json_string_escape entry_point)
-
-(* A module where main handles all effects performed by its callees. *)
 let effects_all_handled_source =
   {|effect Log { log: (String) -> Unit }
 fn helper() -> Unit ! {Log} { perform Log.log("hello") }
@@ -484,439 +218,588 @@ fn main() -> Unit ! pure {
   }
 }|}
 
-(* A module where main calls a function that performs an unhandled effect. *)
 let effects_unhandled_source =
   {|effect Log { log: (String) -> Unit }
 fn helper() -> Unit ! {Log} { perform Log.log("hello") }
 fn main() -> Unit ! {Log} { helper() }|}
 
-let test_verify_effects_in_tools_list () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
-    let line = read_line () in
-    let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
-    let names = match tools with
-      | `List items ->
-        List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
-      | _ -> []
-    in
-    Alcotest.(check bool) "verify_effects in tools/list" true
-      (List.mem "verify_effects" names)
-  )
-
-let test_verify_effects_all_handled () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 effects_all_handled_source "mymod");
-    ignore (read_line ());
-    write_line (verify_effects_call 3 "mymod" "main");
-    let result = parse_response (read_line ()) in
-    let unhandled = json_field "unhandled" result in
-    Alcotest.(check bool) "unhandled is empty list" true
-      (match unhandled with `List [] -> true | _ -> false)
-  )
-
-let test_verify_effects_unhandled () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 effects_unhandled_source "mymod");
-    ignore (read_line ());
-    write_line (verify_effects_call 3 "mymod" "main");
-    let result = parse_response (read_line ()) in
-    let unhandled = json_field "unhandled" result in
-    Alcotest.(check bool) "unhandled is non-empty" true
-      (match unhandled with `List (_ :: _) -> true | _ -> false);
-    (match unhandled with
-     | `List (entry :: _) ->
-       let eff = json_field "effect" entry in
-       Alcotest.(check bool) "effect name is a non-empty string" true
-         (match eff with `String s -> String.length s > 0 | _ -> false);
-       let site = json_field "site" entry in
-       let fn_field = json_field "function" site in
-       Alcotest.(check bool) "site has function field" true
-         (match fn_field with `String s -> String.length s > 0 | _ -> false);
-       let line = json_field "line" site in
-       Alcotest.(check bool) "site has line field" true
-         (match line with `Int _ -> true | _ -> false);
-       let col = json_field "col" site in
-       Alcotest.(check bool) "site has col field" true
-         (match col with `Int _ -> true | _ -> false)
-     | _ -> ())
-  )
-
-let test_verify_effects_module_not_found () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (verify_effects_call 2 "nonexistent" "main");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let test_verify_effects_entry_not_found () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 effects_all_handled_source "mymod");
-    ignore (read_line ());
-    write_line (verify_effects_call 3 "mymod" "nonexistent_fn");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let verify_unused_call id module_name =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"verify_unused","arguments":{"module_name":"%s"}}}|}
-    id (json_string_escape module_name)
-
-(* All non-pub declarations are referenced — expect empty unused list. *)
 let all_used_source =
   {|fn helper(x: Int) -> Int ! pure { x }
 fn main() -> Int ! pure { helper(1) }|}
 
-(* One unreferenced private function. *)
 let one_unused_source =
   {|fn used(x: Int) -> Int ! pure { x }
 fn unused_fn(x: Int) -> Int ! pure { x }
 fn main() -> Int ! pure { used(1) }|}
 
-(* Pub declaration — must NOT be flagged even though nothing calls it. *)
-let pub_unused_source =
-  {|pub fn exported(x: Int) -> Int ! pure { x }|}
+let pub_unused_source = {|pub fn exported(x: Int) -> Int ! pure { x }|}
 
-(* Mutual recursion: both sides referenced externally via main. *)
 let mutual_recursion_source =
   {|fn ping(x: Int) -> Int ! pure { pong(x) }
 fn pong(x: Int) -> Int ! pure { ping(x) }
 fn main() -> Int ! pure { ping(0) }|}
 
-(* Mutual recursion: neither side reachable — both unused. *)
 let mutual_both_unused_source =
   {|fn ping(x: Int) -> Int ! pure { pong(x) }
 fn pong(x: Int) -> Int ! pure { ping(x) }
 fn main() -> Int ! pure { 0 }|}
 
-let test_verify_unused_in_tools_list () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
-    let line = read_line () in
-    let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
-    let names = match tools with
-      | `List items ->
-        List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
-      | _ -> []
-    in
-    Alcotest.(check bool) "verify_unused in tools/list" true
-      (List.mem "verify_unused" names)
-  )
-
-let test_verify_unused_all_used () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 all_used_source "mymod");
-    ignore (read_line ());
-    write_line (verify_unused_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let unused = json_field "unused" result in
-    Alcotest.(check bool) "unused is empty list" true
-      (match unused with `List [] -> true | _ -> false)
-  )
-
-let test_verify_unused_one_unused () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 one_unused_source "mymod");
-    ignore (read_line ());
-    write_line (verify_unused_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let unused = json_field "unused" result in
-    Alcotest.(check bool) "unused is non-empty" true
-      (match unused with `List (_ :: _) -> true | _ -> false);
-    (match unused with
-     | `List (entry :: _) ->
-       let name = json_field "name" entry in
-       Alcotest.(check bool) "entry has name field" true
-         (match name with `String s -> String.length s > 0 | _ -> false);
-       let kind = json_field "kind" entry in
-       Alcotest.(check bool) "entry has kind field" true
-         (match kind with `String s -> String.length s > 0 | _ -> false);
-       let line = json_field "line" entry in
-       Alcotest.(check bool) "entry has line field" true
-         (match line with `Int _ -> true | _ -> false);
-       let col = json_field "col" entry in
-       Alcotest.(check bool) "entry has col field" true
-         (match col with `Int _ -> true | _ -> false)
-     | _ -> ())
-  )
-
-let test_verify_unused_pub_not_flagged () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 pub_unused_source "mymod");
-    ignore (read_line ());
-    write_line (verify_unused_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let unused = json_field "unused" result in
-    Alcotest.(check bool) "pub declaration not flagged" true
-      (match unused with `List [] -> true | _ -> false)
-  )
-
-let test_verify_unused_mutual_recursion_both_reachable () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 mutual_recursion_source "mymod");
-    ignore (read_line ());
-    write_line (verify_unused_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let unused = json_field "unused" result in
-    Alcotest.(check bool) "mutually recursive pair reachable from main — empty unused" true
-      (match unused with `List [] -> true | _ -> false)
-  )
-
-let test_verify_unused_mutual_recursion_both_unreachable () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (submit_module_call 2 mutual_both_unused_source "mymod");
-    ignore (read_line ());
-    write_line (verify_unused_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let unused = json_field "unused" result in
-    let count = match unused with `List xs -> List.length xs | _ -> -1 in
-    Alcotest.(check bool) "both sides of unreachable mutual pair are flagged" true
-      (count = 2)
-  )
-
-let test_verify_unused_module_not_found () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line (verify_unused_call 2 "nonexistent");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
-  )
-
-let query_effects_call id module_name =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_effects","arguments":{"module_name":"%s"}}}|}
-    id (json_string_escape module_name)
-
-(* Pure module — no effects at all. *)
 let pure_module_source =
   {|fn add_one(x: Int) -> Int ! pure { add(x, 1) }
 fn double(x: Int) -> Int ! pure { add(x, x) }|}
 
-(* Module with one effectful function. *)
 let single_effect_source =
   {|effect Log { log: (String) -> Unit }
 fn greet(msg: String) -> Unit ! {Log} { perform Log.log(msg) }
 fn pure_fn(x: Int) -> Int ! pure { x }|}
 
-(* Module where one function performs two effects, another performs one. *)
 let multi_effect_source =
   {|effect Log { log: (String) -> Unit }
 effect Throw { throw: (String) -> Unit }
 fn do_both(x: Int) -> Unit ! {Log, Throw} { perform Log.log("hi") }
 fn do_log(x: Int) -> Unit ! {Log} { perform Log.log("x") }|}
 
-let test_query_effects_in_tools_list () =
+let multi_caller_source =
+  {|fn helper(x: Int) -> Int ! pure { x }
+fn main1() -> Int ! pure { helper(1) }
+fn main2() -> Int ! pure { helper(2) }|}
+
+let uncalled_fn_source =
+  {|fn helper(x: Int) -> Int ! pure { x }
+fn main() -> Int ! pure { 0 }|}
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack and nlen = String.length needle in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let found = ref false in
+    for i = 0 to hlen - nlen do
+      if not !found && String.sub haystack i nlen = needle then found := true
+    done;
+    !found
+
+(* ─── tools/list ─────────────────────────────────────────────────────────── *)
+
+let test_tools_list_has_four_tools () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
     let line = read_line () in
     let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
+    let tools = json_field "tools" (json_field "result" json) in
     let names = match tools with
       | `List items ->
         List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
+          match json_field "name" item with `String s -> Some s | _ -> None) items
       | _ -> []
     in
-    Alcotest.(check bool) "query_effects in tools/list" true
-      (List.mem "query_effects" names)
+    Alcotest.(check int) "exactly four tools" 4 (List.length names);
+    List.iter (fun t ->
+      Alcotest.(check bool) (t ^ " in tools/list") true (List.mem t names)
+    ) ["query"; "write"; "transform"; "verify"]
   )
+
+(* ─── verify / types ─────────────────────────────────────────────────────── *)
+
+let test_verify_types_well_typed () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "verify"
+      (single_cmd "types"
+         (Printf.sprintf {|{"source":"%s"}|} (json_string_escape well_typed_source))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok"  true (batch_ok batch);
+    Alcotest.(check bool) "no diagnostics" true (batch_diagnostics batch = [])
+  )
+
+let test_verify_types_ill_typed () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "verify"
+      (single_cmd "types"
+         (Printf.sprintf {|{"source":"%s"}|} (json_string_escape ill_typed_source))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok (verify never halts on type errors)" true (batch_ok batch);
+    let diags = batch_diagnostics batch in
+    Alcotest.(check bool) "diagnostics non-empty" true (diags <> []);
+    (match diags with
+     | d :: _ ->
+       Alcotest.(check bool) "severity is error" true
+         (json_field "severity" d = `String "error");
+       Alcotest.(check bool) "code present" true
+         (match json_field "code" d with `String s -> String.length s > 0 | _ -> false);
+       Alcotest.(check bool) "message present" true
+         (match json_field "message" d with `String s -> String.length s > 0 | _ -> false)
+     | [] -> ())
+  )
+
+let test_verify_types_does_not_update_state () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    (* verify ill-typed source — must not store anything *)
+    write_line (tool_call 2 "verify"
+      (single_cmd "types"
+         (Printf.sprintf {|{"source":"%s"}|} (json_string_escape ill_typed_source))));
+    ignore (read_line ());
+    (* write well-typed source — must still succeed *)
+    write_line (tool_call 3 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"test"}|}
+            (json_string_escape well_typed_source))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "write succeeds" true (batch_ok batch)
+  )
+
+(* ─── write / submit_module ─────────────────────────────────────────────── *)
+
+let test_write_submit_returns_hash () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let hash = json_field "hash" (first_result batch) in
+    Alcotest.(check bool) "hash is a non-empty string" true
+      (match hash with `String s -> String.length s > 0 | _ -> false)
+  )
+
+let test_write_parse_error_halts () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         {|{"source":"@@@invalid@@@","module_name":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch));
+    let diags = batch_diagnostics batch in
+    Alcotest.(check bool) "error diagnostic present" true (diags <> []);
+    (match diags with
+     | d :: _ ->
+       Alcotest.(check bool) "severity is error" true
+         (json_field "severity" d = `String "error")
+     | [] -> ())
+  )
+
+(* ─── query / signature ─────────────────────────────────────────────────── *)
+
+let test_query_signature_success () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "query"
+      (single_cmd "signature" {|{"module":"mymod","name":"double"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let sig_ = json_field "signature" (first_result batch) in
+    Alcotest.(check bool) "signature is non-empty string" true
+      (match sig_ with `String s -> String.length s > 0 | _ -> false);
+    let node = json_field "node" (first_result batch) in
+    Alcotest.(check bool) "node hash present" true
+      (match node with `String s -> String.length s > 0 | _ -> false)
+  )
+
+let test_query_signature_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "query"
+      (single_cmd "signature" {|{"module":"nonexistent","name":"double"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch));
+    let diags = batch_diagnostics batch in
+    Alcotest.(check bool) "error diagnostic present" true (diags <> [])
+  )
+
+let test_query_signature_function_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "query"
+      (single_cmd "signature" {|{"module":"mymod","name":"nonexistent_fn"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch));
+    let diags = batch_diagnostics batch in
+    Alcotest.(check bool) "error diagnostic present" true (diags <> [])
+  )
+
+(* ─── query / interface ─────────────────────────────────────────────────── *)
+
+let test_query_interface_returns_only_pub () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape mixed_visibility_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "query"
+      (single_cmd "interface" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let iface = match json_field "interface" (first_result batch) with
+      | `String s -> s | _ -> "" in
+    Alcotest.(check bool) "contains pub fn"      true (contains_substring iface "pub fn add_one");
+    Alcotest.(check bool) "contains pub type"    true (contains_substring iface "pub type Color");
+    Alcotest.(check bool) "excludes private fn"  true (not (contains_substring iface "internal_helper"))
+  )
+
+let test_query_interface_fn_has_no_body () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape mixed_visibility_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "query"
+      (single_cmd "interface" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    let iface = match json_field "interface" (first_result batch) with
+      | `String s -> s | _ -> "" in
+    Alcotest.(check bool) "interface non-empty"     true (String.length iface > 0);
+    Alcotest.(check bool) "no body braces"          true (not (String.contains iface '{'))
+  )
+
+let test_query_interface_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "query"
+      (single_cmd "interface" {|{"module":"nonexistent"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
+  )
+
+(* ─── verify / exhaustive ────────────────────────────────────────────────── *)
+
+let test_verify_exhaustive_no_warnings () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape exhaustive_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "exhaustive" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    Alcotest.(check bool) "no diagnostics" true (batch_diagnostics batch = [])
+  )
+
+let test_verify_exhaustive_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "verify"
+      (single_cmd "exhaustive" {|{"module":"nonexistent"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
+  )
+
+(* ─── verify / effects ───────────────────────────────────────────────────── *)
+
+let test_verify_effects_all_handled () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape effects_all_handled_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "effects" {|{"module":"mymod","entry_point":"main"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    Alcotest.(check bool) "no diagnostics" true (batch_diagnostics batch = [])
+  )
+
+let test_verify_effects_unhandled () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape effects_unhandled_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "effects" {|{"module":"mymod","entry_point":"main"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let diags = batch_diagnostics batch in
+    Alcotest.(check bool) "diagnostics non-empty" true (diags <> []);
+    (match diags with
+     | d :: _ ->
+       Alcotest.(check bool) "severity is warning" true
+         (json_field "severity" d = `String "warning");
+       Alcotest.(check bool) "code is effect/unhandled" true
+         (json_field "code" d = `String "effect/unhandled");
+       Alcotest.(check bool) "location present" true
+         (match json_field "location" d with `Assoc _ -> true | _ -> false)
+     | [] -> ())
+  )
+
+let test_verify_effects_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "verify"
+      (single_cmd "effects" {|{"module":"nonexistent","entry_point":"main"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
+  )
+
+let test_verify_effects_entry_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape effects_all_handled_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "effects" {|{"module":"mymod","entry_point":"nonexistent_fn"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
+  )
+
+(* ─── verify / unused ────────────────────────────────────────────────────── *)
+
+let test_verify_unused_all_used () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape all_used_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "unused" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    Alcotest.(check bool) "no diagnostics" true (batch_diagnostics batch = [])
+  )
+
+let test_verify_unused_one_unused () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape one_unused_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "unused" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let diags = batch_diagnostics batch in
+    Alcotest.(check bool) "diagnostics non-empty" true (diags <> []);
+    (match diags with
+     | d :: _ ->
+       Alcotest.(check bool) "severity is warning" true
+         (json_field "severity" d = `String "warning");
+       Alcotest.(check bool) "code is decl/unused" true
+         (json_field "code" d = `String "decl/unused");
+       Alcotest.(check bool) "message non-empty" true
+         (match json_field "message" d with `String s -> String.length s > 0 | _ -> false);
+       Alcotest.(check bool) "location present" true
+         (match json_field "location" d with `Assoc _ -> true | _ -> false)
+     | [] -> ())
+  )
+
+let test_verify_unused_pub_not_flagged () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape pub_unused_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "unused" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "no diagnostics for pub decl" true (batch_diagnostics batch = [])
+  )
+
+let test_verify_unused_mutual_recursion_both_reachable () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape mutual_recursion_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "unused" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "no diagnostics — pair reachable from main" true
+      (batch_diagnostics batch = [])
+  )
+
+let test_verify_unused_mutual_recursion_both_unreachable () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape mutual_both_unused_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "unused" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "two diagnostics — both sides flagged" true
+      (List.length (batch_diagnostics batch) = 2)
+  )
+
+let test_verify_unused_module_not_found () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "verify"
+      (single_cmd "unused" {|{"module":"nonexistent"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
+  )
+
+(* ─── query / effects ────────────────────────────────────────────────────── *)
 
 let test_query_effects_module_not_found () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (query_effects_call 2 "nonexistent");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
+    write_line (tool_call 2 "query"
+      (single_cmd "effects" {|{"module":"nonexistent"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
   )
 
 let test_query_effects_pure_module () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (submit_module_call 2 pure_module_source "mymod");
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape pure_module_source))));
     ignore (read_line ());
-    write_line (query_effects_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let effects = json_field "effects" result in
+    write_line (tool_call 3 "query"
+      (single_cmd "effects" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let effs = json_field "effects" (first_result batch) in
     Alcotest.(check bool) "effects is empty object" true
-      (match effects with `Assoc [] -> true | _ -> false)
+      (match effs with `Assoc [] -> true | _ -> false)
   )
 
 let test_query_effects_single_effect () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (submit_module_call 2 single_effect_source "mymod");
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape single_effect_source))));
     ignore (read_line ());
-    write_line (query_effects_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let effects = json_field "effects" result in
-    let log_fns = match effects with
-      | `Assoc fields -> (match List.assoc_opt "Log" fields with Some v -> v | None -> `Null)
+    write_line (tool_call 3 "query"
+      (single_cmd "effects" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    let effs = json_field "effects" (first_result batch) in
+    let log_fns = match effs with
+      | `Assoc fs -> (match List.assoc_opt "Log" fs with Some v -> v | None -> `Null)
       | _ -> `Null
     in
-    Alcotest.(check bool) "Log effect maps to greet" true
-      (match log_fns with
-       | `List fns -> List.exists (fun f -> f = `String "greet") fns
-       | _ -> false);
-    Alcotest.(check bool) "pure_fn not in Log's list" true
-      (match log_fns with
-       | `List fns -> not (List.exists (fun f -> f = `String "pure_fn") fns)
-       | _ -> false)
+    Alcotest.(check bool) "Log maps to greet" true
+      (match log_fns with `List fns -> List.mem (`String "greet") fns | _ -> false);
+    Alcotest.(check bool) "pure_fn not in Log" true
+      (match log_fns with `List fns -> not (List.mem (`String "pure_fn") fns) | _ -> false)
   )
 
 let test_query_effects_multi_effect () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (submit_module_call 2 multi_effect_source "mymod");
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape multi_effect_source))));
     ignore (read_line ());
-    write_line (query_effects_call 3 "mymod");
-    let result = parse_response (read_line ()) in
-    let effects = json_field "effects" result in
-    let get_fns eff_name = match effects with
-      | `Assoc fields -> (match List.assoc_opt eff_name fields with Some v -> v | None -> `Null)
+    write_line (tool_call 3 "query"
+      (single_cmd "effects" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    let effs = json_field "effects" (first_result batch) in
+    let get e = match effs with
+      | `Assoc fs -> (match List.assoc_opt e fs with Some v -> v | None -> `Null)
       | _ -> `Null
     in
-    let log_fns = get_fns "Log" in
-    let throw_fns = get_fns "Throw" in
-    Alcotest.(check bool) "do_both appears under Log" true
-      (match log_fns with
-       | `List fns -> List.exists (fun f -> f = `String "do_both") fns
-       | _ -> false);
-    Alcotest.(check bool) "do_log appears under Log" true
-      (match log_fns with
-       | `List fns -> List.exists (fun f -> f = `String "do_log") fns
-       | _ -> false);
-    Alcotest.(check bool) "do_both appears under Throw" true
-      (match throw_fns with
-       | `List fns -> List.exists (fun f -> f = `String "do_both") fns
-       | _ -> false);
-    Alcotest.(check bool) "do_log does not appear under Throw" true
-      (match throw_fns with
-       | `List fns -> not (List.exists (fun f -> f = `String "do_log") fns)
-       | _ -> false)
+    let log_fns   = get "Log" in
+    let throw_fns = get "Throw" in
+    Alcotest.(check bool) "do_both under Log"    true
+      (match log_fns   with `List fs -> List.mem (`String "do_both") fs | _ -> false);
+    Alcotest.(check bool) "do_log under Log"     true
+      (match log_fns   with `List fs -> List.mem (`String "do_log")  fs | _ -> false);
+    Alcotest.(check bool) "do_both under Throw"  true
+      (match throw_fns with `List fs -> List.mem (`String "do_both") fs | _ -> false);
+    Alcotest.(check bool) "do_log not under Throw" true
+      (match throw_fns with `List fs -> not (List.mem (`String "do_log") fs) | _ -> false)
   )
 
-let query_callers_call id module_name function_name =
-  Printf.sprintf
-    {|{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"query_callers","arguments":{"module_name":"%s","function_name":"%s"}}}|}
-    id (json_string_escape module_name) (json_string_escape function_name)
-
-(* helper is called from both main1 and main2 *)
-let multi_caller_source =
-  {|fn helper(x: Int) -> Int ! pure { x }
-fn main1() -> Int ! pure { helper(1) }
-fn main2() -> Int ! pure { helper(2) }|}
-
-(* helper is defined but never called *)
-let uncalled_fn_source =
-  {|fn helper(x: Int) -> Int ! pure { x }
-fn main() -> Int ! pure { 0 }|}
-
-let test_query_callers_in_tools_list () =
-  let (write_line, read_line, close) = start_server () in
-  Fun.protect ~finally:close (fun () ->
-    initialize write_line read_line;
-    write_line {|{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}|};
-    let line = read_line () in
-    let json = mini_parse line in
-    let result = json_field "result" json in
-    let tools = json_field "tools" result in
-    let names = match tools with
-      | `List items ->
-        List.filter_map (fun item ->
-          match json_field "name" item with
-          | `String s -> Some s
-          | _ -> None) items
-      | _ -> []
-    in
-    Alcotest.(check bool) "query_callers in tools/list" true
-      (List.mem "query_callers" names)
-  )
+(* ─── query / callers ────────────────────────────────────────────────────── *)
 
 let test_query_callers_multiple_callers () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (submit_module_call 2 multi_caller_source "mymod");
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape multi_caller_source))));
     ignore (read_line ());
-    write_line (query_callers_call 3 "mymod" "helper");
-    let result = parse_response (read_line ()) in
-    let callers = json_field "callers" result in
-    Alcotest.(check bool) "callers list has two entries" true
+    write_line (tool_call 3 "query"
+      (single_cmd "callers" {|{"module":"mymod","name":"helper"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let callers = json_field "callers" (first_result batch) in
+    Alcotest.(check bool) "two callers" true
       (match callers with `List xs -> List.length xs = 2 | _ -> false);
     (match callers with
      | `List (entry :: _) ->
-       let caller = json_field "caller" entry in
-       Alcotest.(check bool) "entry has non-empty caller field" true
-         (match caller with `String s -> String.length s > 0 | _ -> false);
-       let line = json_field "line" entry in
-       Alcotest.(check bool) "entry has line field" true
-         (match line with `Int _ -> true | _ -> false);
-       let col = json_field "col" entry in
-       Alcotest.(check bool) "entry has col field" true
-         (match col with `Int _ -> true | _ -> false)
+       Alcotest.(check bool) "caller field non-empty" true
+         (match json_field "caller" entry with `String s -> String.length s > 0 | _ -> false);
+       Alcotest.(check bool) "line field present" true
+         (match json_field "line" entry with `Int _ -> true | _ -> false);
+       Alcotest.(check bool) "col field present" true
+         (match json_field "col" entry with `Int _ -> true | _ -> false)
      | _ -> ())
   )
 
@@ -924,12 +807,17 @@ let test_query_callers_uncalled_function () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (submit_module_call 2 uncalled_fn_source "mymod");
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape uncalled_fn_source))));
     ignore (read_line ());
-    write_line (query_callers_call 3 "mymod" "helper");
-    let result = parse_response (read_line ()) in
-    let callers = json_field "callers" result in
-    Alcotest.(check bool) "callers is empty list for uncalled function" true
+    write_line (tool_call 3 "query"
+      (single_cmd "callers" {|{"module":"mymod","name":"helper"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let callers = json_field "callers" (first_result batch) in
+    Alcotest.(check bool) "empty callers list" true
       (match callers with `List [] -> true | _ -> false)
   )
 
@@ -937,87 +825,175 @@ let test_query_callers_module_not_found () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (query_callers_call 2 "nonexistent" "helper");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
+    write_line (tool_call 2 "query"
+      (single_cmd "callers" {|{"module":"nonexistent","name":"helper"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
   )
 
 let test_query_callers_function_not_defined () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
-    write_line (submit_module_call 2 multi_caller_source "mymod");
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape multi_caller_source))));
     ignore (read_line ());
-    write_line (query_callers_call 3 "mymod" "nonexistent_fn");
-    let result = parse_response (read_line ()) in
-    let ok = json_field "ok" result in
-    Alcotest.(check bool) "ok is false" true
-      (match ok with `Bool false -> true | _ -> false);
-    let err = json_field "error" result in
-    Alcotest.(check bool) "error is non-empty string" true
-      (match err with `String s -> String.length s > 0 | _ -> false)
+    write_line (tool_call 3 "query"
+      (single_cmd "callers" {|{"module":"mymod","name":"nonexistent_fn"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
   )
 
+(* ─── batch semantics: multi-command and early halt ─────────────────────── *)
+
+let test_batch_multi_command_all_succeed () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    (* Two query commands in one batch *)
+    let cmds = Printf.sprintf
+        {|[{"op":"signature","args":{"module":"mymod","name":"double"}},{"op":"interface","args":{"module":"mymod"}}]|}
+    in
+    write_line (tool_call 3 "query" cmds);
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let results = match json_field "results" batch with `List rs -> rs | _ -> [] in
+    Alcotest.(check int) "two results" 2 (List.length results)
+  )
+
+let test_batch_halts_at_first_unrecoverable () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    (* First command fails (module not found), second would succeed *)
+    let cmds = Printf.sprintf
+        {|[{"op":"signature","args":{"module":"no_such","name":"double"}},{"op":"signature","args":{"module":"mymod","name":"double"}}]|}
+    in
+    write_line (tool_call 3 "query" cmds);
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch));
+    Alcotest.(check bool) "stopped_at is 0" true
+      (json_field "stopped_at" batch = `Int 0);
+    let results = match json_field "results" batch with `List rs -> rs | _ -> [] in
+    Alcotest.(check int) "zero results before halt" 0 (List.length results)
+  )
+
+(* ─── diagnostic node hash population ───────────────────────────────────── *)
+
+let test_verify_effects_diagnostic_has_node () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape effects_unhandled_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "effects" {|{"module":"mymod","entry_point":"main"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    (match batch_diagnostics batch with
+     | d :: _ ->
+       Alcotest.(check bool) "diagnostic has node hash" true
+         (match json_field "node" d with `String s -> String.length s > 0 | _ -> false)
+     | [] ->
+       Alcotest.fail "expected at least one diagnostic")
+  )
+
+let test_verify_unused_diagnostic_has_node () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "submit_module"
+         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+            (json_string_escape one_unused_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "verify"
+      (single_cmd "unused" {|{"module":"mymod"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    (match batch_diagnostics batch with
+     | d :: _ ->
+       Alcotest.(check bool) "diagnostic has node hash" true
+         (match json_field "node" d with `String s -> String.length s > 0 | _ -> false)
+     | [] ->
+       Alcotest.fail "expected at least one diagnostic")
+  )
+
+(* ─── Test runner ────────────────────────────────────────────────────────── *)
+
 let () =
-  ignore well_typed_source;
-  ignore ill_typed_source;
   Alcotest.run "mcp_server" [
-    ("verify_types", [
-      Alcotest.test_case "well-typed program returns empty errors"    `Quick test_verify_types_well_typed;
-      Alcotest.test_case "ill-typed program returns non-empty errors" `Quick test_verify_types_type_error;
-      Alcotest.test_case "does not update server state"               `Quick test_verify_types_does_not_update_state;
-      Alcotest.test_case "appears in tools/list"                      `Quick test_tools_list_includes_verify_types;
+    ("tools/list", [
+      Alcotest.test_case "exposes exactly four tools" `Quick test_tools_list_has_four_tools;
     ]);
-    ("query_signature", [
-      Alcotest.test_case "returns signature for known function"              `Quick test_query_signature_success;
-      Alcotest.test_case "returns error when module not found"               `Quick test_query_signature_module_not_found;
-      Alcotest.test_case "returns error when function not found in module"   `Quick test_query_signature_function_not_found;
-      Alcotest.test_case "appears in tools/list"                             `Quick test_query_signature_in_tools_list;
+    ("verify/types", [
+      Alcotest.test_case "well-typed source → no diagnostics"    `Quick test_verify_types_well_typed;
+      Alcotest.test_case "ill-typed source → error diagnostics"  `Quick test_verify_types_ill_typed;
+      Alcotest.test_case "does not update server state"          `Quick test_verify_types_does_not_update_state;
     ]);
-    ("query_interface", [
-      Alcotest.test_case "returns only pub declarations"                     `Quick test_query_interface_returns_only_pub;
-      Alcotest.test_case "function signatures have no body"                  `Quick test_query_interface_fn_has_no_body;
-      Alcotest.test_case "returns error when module not found"               `Quick test_query_interface_module_not_found;
-      Alcotest.test_case "appears in tools/list"                             `Quick test_query_interface_in_tools_list;
+    ("write/submit_module", [
+      Alcotest.test_case "returns BLAKE3 hash on success"        `Quick test_write_submit_returns_hash;
+      Alcotest.test_case "parse error halts batch"               `Quick test_write_parse_error_halts;
     ]);
-    ("verify_exhaustive", [
-      Alcotest.test_case "appears in tools/list"                             `Quick test_verify_exhaustive_in_tools_list;
-      Alcotest.test_case "returns empty warnings for exhaustive module"      `Quick test_verify_exhaustive_exhaustive_module;
-      Alcotest.test_case "returns error when module not found"               `Quick test_verify_exhaustive_module_not_found;
+    ("query/signature", [
+      Alcotest.test_case "returns signature and node hash"       `Quick test_query_signature_success;
+      Alcotest.test_case "module not found halts batch"          `Quick test_query_signature_module_not_found;
+      Alcotest.test_case "function not found halts batch"        `Quick test_query_signature_function_not_found;
     ]);
-    ("verify_effects", [
-      Alcotest.test_case "appears in tools/list"                             `Quick test_verify_effects_in_tools_list;
-      Alcotest.test_case "returns empty unhandled when all effects handled"  `Quick test_verify_effects_all_handled;
-      Alcotest.test_case "returns unhandled entries when effects escape"     `Quick test_verify_effects_unhandled;
-      Alcotest.test_case "returns error when module not found"               `Quick test_verify_effects_module_not_found;
-      Alcotest.test_case "returns error when entry point not found"          `Quick test_verify_effects_entry_not_found;
+    ("query/interface", [
+      Alcotest.test_case "returns only pub declarations"         `Quick test_query_interface_returns_only_pub;
+      Alcotest.test_case "function signatures have no body"      `Quick test_query_interface_fn_has_no_body;
+      Alcotest.test_case "module not found halts batch"          `Quick test_query_interface_module_not_found;
     ]);
-    ("verify_unused", [
-      Alcotest.test_case "appears in tools/list"                                         `Quick test_verify_unused_in_tools_list;
-      Alcotest.test_case "returns empty list when all declarations are used"             `Quick test_verify_unused_all_used;
-      Alcotest.test_case "returns entry for unreferenced function"                       `Quick test_verify_unused_one_unused;
-      Alcotest.test_case "does not flag pub declarations"                                `Quick test_verify_unused_pub_not_flagged;
-      Alcotest.test_case "mutual recursion reachable from main — no unused"             `Quick test_verify_unused_mutual_recursion_both_reachable;
-      Alcotest.test_case "mutual recursion unreachable from roots — both flagged"       `Quick test_verify_unused_mutual_recursion_both_unreachable;
-      Alcotest.test_case "returns error when module not found"                           `Quick test_verify_unused_module_not_found;
+    ("verify/exhaustive", [
+      Alcotest.test_case "exhaustive match → no diagnostics"     `Quick test_verify_exhaustive_no_warnings;
+      Alcotest.test_case "module not found halts batch"          `Quick test_verify_exhaustive_module_not_found;
     ]);
-    ("query_effects", [
-      Alcotest.test_case "appears in tools/list"                                         `Quick test_query_effects_in_tools_list;
-      Alcotest.test_case "returns error when module not found"                           `Quick test_query_effects_module_not_found;
-      Alcotest.test_case "returns empty effects map for pure module"                     `Quick test_query_effects_pure_module;
-      Alcotest.test_case "maps single effect to performing function"                     `Quick test_query_effects_single_effect;
-      Alcotest.test_case "function with multiple effects appears under each"             `Quick test_query_effects_multi_effect;
+    ("verify/effects", [
+      Alcotest.test_case "all handled → no diagnostics"          `Quick test_verify_effects_all_handled;
+      Alcotest.test_case "unhandled effects → warning diags"     `Quick test_verify_effects_unhandled;
+      Alcotest.test_case "module not found halts batch"          `Quick test_verify_effects_module_not_found;
+      Alcotest.test_case "entry point not found halts batch"     `Quick test_verify_effects_entry_not_found;
     ]);
-    ("query_callers", [
-      Alcotest.test_case "appears in tools/list"                                         `Quick test_query_callers_in_tools_list;
-      Alcotest.test_case "returns all call sites when function is called multiple times" `Quick test_query_callers_multiple_callers;
-      Alcotest.test_case "returns empty list for defined but uncalled function"          `Quick test_query_callers_uncalled_function;
-      Alcotest.test_case "returns error when module not found"                           `Quick test_query_callers_module_not_found;
-      Alcotest.test_case "returns error when function not defined in module"             `Quick test_query_callers_function_not_defined;
+    ("verify/unused", [
+      Alcotest.test_case "all used → no diagnostics"             `Quick test_verify_unused_all_used;
+      Alcotest.test_case "unused fn → warning diagnostic"        `Quick test_verify_unused_one_unused;
+      Alcotest.test_case "pub decl not flagged"                  `Quick test_verify_unused_pub_not_flagged;
+      Alcotest.test_case "mutual recursion reachable — clean"    `Quick test_verify_unused_mutual_recursion_both_reachable;
+      Alcotest.test_case "mutual recursion unreachable — flagged" `Quick test_verify_unused_mutual_recursion_both_unreachable;
+      Alcotest.test_case "module not found halts batch"          `Quick test_verify_unused_module_not_found;
+    ]);
+    ("query/effects", [
+      Alcotest.test_case "module not found halts batch"          `Quick test_query_effects_module_not_found;
+      Alcotest.test_case "pure module → empty effects map"       `Quick test_query_effects_pure_module;
+      Alcotest.test_case "single effect → correct mapping"       `Quick test_query_effects_single_effect;
+      Alcotest.test_case "multi-effect fn appears under each"    `Quick test_query_effects_multi_effect;
+    ]);
+    ("query/callers", [
+      Alcotest.test_case "multiple callers returned"             `Quick test_query_callers_multiple_callers;
+      Alcotest.test_case "uncalled fn → empty list"              `Quick test_query_callers_uncalled_function;
+      Alcotest.test_case "module not found halts batch"          `Quick test_query_callers_module_not_found;
+      Alcotest.test_case "fn not defined halts batch"            `Quick test_query_callers_function_not_defined;
+    ]);
+    ("batch/semantics", [
+      Alcotest.test_case "multi-command batch all succeed"       `Quick test_batch_multi_command_all_succeed;
+      Alcotest.test_case "halts at first unrecoverable error"    `Quick test_batch_halts_at_first_unrecoverable;
+    ]);
+    ("diagnostic/node", [
+      Alcotest.test_case "effect diagnostic carries node hash"   `Quick test_verify_effects_diagnostic_has_node;
+      Alcotest.test_case "unused diagnostic carries node hash"   `Quick test_verify_unused_diagnostic_has_node;
     ]);
   ]


### PR DESCRIPTION
## Summary

This PR implements the MCP (Model Context Protocol) batch request/response protocol for the Axiom language server, establishing a unified diagnostic schema shared across all four tool handlers (`query`, `write`, `transform`, `verify`). This is foundational work for issues #82 and #83.

## Key Changes

- **New MCP library** (`lib/mcp/`): Created `mcp_types.ml` with shared OCaml types for the batch protocol:
  - `severity` enum (error, warning, info)
  - `location` record for source positions
  - `related_ref` for secondary diagnostic references
  - `diagnostic` record as the single canonical diagnostic type used by all tools

- **Batch protocol implementation** (`bin/mcp_server.ml`):
  - Replaced individual tool-specific request/response handlers with a unified batch executor (`batch_execute`)
  - All four tools now accept a `commands` array and return a single `batch_response` shape:
    - `results`: array of per-command outcomes
    - `stopped_at`: index where execution halted (null if completed)
    - `diagnostics`: accumulated diagnostics from all commands
  - Introduced `cmd_outcome` type to distinguish recoverable diagnostics from unrecoverable halts
  - Added `module_state` field `root_hash` and `decl_hashes` table for content-addressed node tracking

- **Tool surface consolidation**:
  - `query` tool: `signature`, `interface`, `effects`, `callers` operations
  - `write` tool: `submit_module` operation
  - `verify` tool: `types`, `exhaustive`, `effects`, `unused` operations
  - `transform` tool: stub (no operations yet)

- **Test suite refactoring** (`test/test_mcp_server.ml`):
  - Reorganized ~860 lines of tests into logical sections with visual separators
  - Updated all test cases to use new batch protocol helpers (`tool_call`, `single_cmd`, `parse_batch_response`)
  - Added comprehensive test sources for various language features (effects, exhaustiveness, unused declarations, mutual recursion)
  - Tests now verify batch-level semantics (stopped_at, diagnostics accumulation)

- **Documentation** (`docs/implementation/mcp.md`):
  - New reference document describing the batch protocol wire format
  - Tool surface and valid operations per tool
  - Command argument shapes for all operations
  - Batch response schema and per-op result shapes
  - Diagnostic schema with field semantics

## Notable Implementation Details

- **Compile-time safety**: Using shared OCaml record types for diagnostics makes it a compile error for any tool to diverge from the schema
- **Batch semantics**: Commands execute sequentially; unrecoverable failures halt the batch at the current index while recoverable diagnostics accumulate
- **Content addressing**: Module state now tracks BLAKE3 hashes of the program root and individual declarations for future IR graph queries
- **Backward compatibility**: JSON-RPC envelope and initialization flow remain unchanged; only the tool call payload structure is new

https://claude.ai/code/session_01TGB17nGNikDpmKNedJpYXR