### PR TITLE
Refactor write tool: rename submit_module to module, add function and replace ops

### DIFF
--- a/bin/mcp_server.ml
+++ b/bin/mcp_server.ml
@@ -1437,72 +1437,177 @@ let dispatch_query state cmd =
 
 (* ─── Write tool ─────────────────────────────────────────────────────────── *)
 
-(* After storing a module, run all verify passes and collect diagnostics. *)
-let post_write_verify ms =
+(* Encode an AST to root hash + per-decl hashes. *)
+let encode_ast state ast =
+  let enc  = Node_store.as_encoding_store state.node_store in
+  let root = Node_encoding.encode_program enc ast in
+  let root_hash = bytes_to_hex root in
+  let enc2 = Node_store.as_encoding_store state.node_store in
+  let decl_hashes = Hashtbl.create 16 in
+  List.iter (fun decl ->
+    match decl_name decl with
+    | Some n -> Hashtbl.replace decl_hashes n
+                  (bytes_to_hex (Node_encoding.encode_decl enc2 decl))
+    | None   -> ()) ast;
+  (root_hash, decl_hashes)
+
+(* Build the {root, nodes} result object from encoded hashes. *)
+let make_write_result root_hash decl_hashes =
+  let nodes_list   = Hashtbl.fold (fun n h acc -> (n, String h) :: acc) decl_hashes [] in
+  let nodes_sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) nodes_list in
+  Object [("root", String root_hash); ("nodes", Object nodes_sorted)]
+
+(* Store a module, persisting the source. *)
+let store_module state name source ms =
+  Hashtbl.replace state.modules name ms;
+  Hashtbl.replace state.sources name source;
+  save_module_registry state.store_dir state.sources
+
+(* Run the post-batch verification checks on all modules in state.
+   Handles "exhaustive" and "unused"; "types" is implicit (checked per-command);
+   "effects" is skipped without an entry point. *)
+let run_post_batch_verify state verify_checks =
   let diags = ref [] in
-  (* match exhaustiveness warnings *)
-  List.iter (fun (w : Typechecker.match_warning) ->
-    let msg = Printf.sprintf "Non-exhaustive match; missing: %s"
-        (String.concat ", " w.mw_missing) in
-    let node = match w.mw_fn_name with
-      | Some fn -> (match Hashtbl.find_opt ms.decl_hashes fn with
-          | Some h -> h | None -> ms.root_hash)
-      | None -> ms.root_hash
-    in
-    diags := !diags @ [Mcp_types.make_warning
-        ~node
-        ~location:(make_loc w.mw_line w.mw_col)
-        "match/non-exhaustive" msg]
-  ) (Typechecker.collect_match_warnings ms.typed_ast);
-  (* unused declarations *)
-  List.iter (fun (u : Typechecker.unused_item) ->
-    let node = Hashtbl.find_opt ms.decl_hashes u.ui_name in
-    let msg = Printf.sprintf "Unused %s '%s'" u.ui_kind u.ui_name in
-    diags := !diags @ [Mcp_types.make_warning
-        ?node
-        ~location:(make_loc u.ui_line u.ui_col)
-        "decl/unused" msg]
-  ) (Typechecker.collect_unused ms.typed_ast);
+  Hashtbl.iter (fun _name ms ->
+    if List.mem "exhaustive" verify_checks then
+      List.iter (fun (w : Typechecker.match_warning) ->
+        let msg  = Printf.sprintf "Non-exhaustive match; missing: %s"
+                     (String.concat ", " w.mw_missing) in
+        let node = match w.mw_fn_name with
+          | Some fn -> (match Hashtbl.find_opt ms.decl_hashes fn with
+              | Some h -> h | None -> ms.root_hash)
+          | None -> ms.root_hash
+        in
+        diags := !diags @ [Mcp_types.make_warning ~node
+                             ~location:(make_loc w.mw_line w.mw_col)
+                             "match/non-exhaustive" msg]
+      ) (Typechecker.collect_match_warnings ms.typed_ast);
+    if List.mem "unused" verify_checks then
+      List.iter (fun (u : Typechecker.unused_item) ->
+        let node = Hashtbl.find_opt ms.decl_hashes u.ui_name in
+        let msg  = Printf.sprintf "Unused %s '%s'" u.ui_kind u.ui_name in
+        diags := !diags @ [Mcp_types.make_warning ?node
+                             ~location:(make_loc u.ui_line u.ui_col)
+                             "decl/unused" msg]
+      ) (Typechecker.collect_unused ms.typed_ast)
+  ) state.modules;
   !diags
 
 let dispatch_write state cmd =
   let op   = match obj_get "op"   cmd with String s -> s | _ -> "" in
   let args = obj_get "args" cmd in
   match op with
-  | "submit_module" ->
-    let source      = match obj_get "source"      args with String s -> s | _ -> "" in
-    let module_name = match obj_get "module_name" args with String s -> s | _ -> "" in
-    (try
-       let tokens    = Lexer.tokenize source in
-       let ast       = Parser.parse_program tokens in
-       let (type_env, effect_env) = Typechecker.check_program ast in
-       let enc       = Node_store.as_encoding_store state.node_store in
-       let root      = Node_encoding.encode_program enc ast in
-       let root_hash = bytes_to_hex root in
-       let enc2      = Node_store.as_encoding_store state.node_store in
-       let decl_hashes = Hashtbl.create 16 in
-       List.iter (fun decl ->
-         match decl_name decl with
-         | Some n ->
-           let h = Node_encoding.encode_decl enc2 decl in
-           Hashtbl.replace decl_hashes n (bytes_to_hex h)
-         | None -> ()
-       ) ast;
-       let ms = { typed_ast = ast; type_env; effect_env; root_hash; decl_hashes } in
-       Hashtbl.replace state.modules module_name ms;
-       (* Persist source so the module survives a server restart. *)
-       Hashtbl.replace state.sources module_name source;
-       save_module_registry state.store_dir state.sources;
-       let verify_diags = post_write_verify ms in
-       let nodes_list = Hashtbl.fold (fun name hash acc ->
-           (name, String hash) :: acc) decl_hashes [] in
-       let nodes_sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) nodes_list in
-       Cmd_success (Object [
-           ("root",  String root_hash);
-           ("nodes", Object nodes_sorted);
-         ], verify_diags)
-     with Failure msg ->
-       Cmd_halt (Mcp_types.make_error "parse/error" msg))
+
+  (* ── module: parse + elaborate + store a full working-form module ──────── *)
+  | "module" ->
+    let name   = match obj_get "name"   args with String s -> s | _ -> "" in
+    let source = match obj_get "source" args with String s -> s | _ -> "" in
+    if name = "" then
+      Cmd_halt (Mcp_types.make_error "command/invalid"
+        "module op requires a non-empty 'name' field")
+    else
+    let parse_result =
+      try let tokens = Lexer.tokenize source in
+          Ok (Parser.parse_program tokens)
+      with Failure msg -> Error msg
+    in
+    (match parse_result with
+     | Error msg -> Cmd_halt (Mcp_types.make_error "parse/error" msg)
+     | Ok ast ->
+       let (root_hash, decl_hashes) = encode_ast state ast in
+       let result = make_write_result root_hash decl_hashes in
+       let type_result =
+         try Ok (Typechecker.check_program ast) with Failure msg -> Error msg
+       in
+       (match type_result with
+        | Error msg ->
+          let ms = { typed_ast = ast; type_env = []; effect_env = [];
+                     root_hash; decl_hashes } in
+          store_module state name source ms;
+          Cmd_success (result, [Mcp_types.make_error "type/error" msg])
+        | Ok (type_env, effect_env) ->
+          let ms = { typed_ast = ast; type_env; effect_env; root_hash; decl_hashes } in
+          store_module state name source ms;
+          Cmd_success (result, [])))
+
+  (* ── function: add / replace a single declaration in an existing module ── *)
+  | "function" ->
+    let module_name = match obj_get "module" args with String s -> s | _ -> "" in
+    let source      = match obj_get "source" args with String s -> s | _ -> "" in
+    (match Hashtbl.find_opt state.modules module_name with
+     | None ->
+       Cmd_halt (Mcp_types.make_error "anchor/not-found"
+         (Printf.sprintf "Module '%s' not found" module_name))
+     | Some ms ->
+       let parse_result =
+         try let tokens = Lexer.tokenize source in
+             Ok (Parser.parse_program tokens)
+         with Failure msg -> Error msg
+       in
+       (match parse_result with
+        | Error msg -> Cmd_halt (Mcp_types.make_error "parse/error" msg)
+        | Ok new_decls ->
+          let new_names  = List.filter_map decl_name new_decls in
+          let kept       = List.filter (fun d ->
+            match decl_name d with
+            | Some n -> not (List.mem n new_names)
+            | None   -> true) ms.typed_ast in
+          let combined   = kept @ new_decls in
+          let (root_hash, decl_hashes) = encode_ast state combined in
+          let result     = make_write_result root_hash decl_hashes in
+          let type_result =
+            try Ok (Typechecker.check_program combined) with Failure msg -> Error msg
+          in
+          let new_source = Printer.print_program combined in
+          (match type_result with
+           | Error msg ->
+             let updated = { typed_ast = combined; root_hash; decl_hashes;
+                             type_env = []; effect_env = [] } in
+             store_module state module_name new_source updated;
+             Cmd_success (result, [Mcp_types.make_error "type/error" msg])
+           | Ok (type_env, effect_env) ->
+             let updated = { typed_ast = combined; type_env; effect_env;
+                             root_hash; decl_hashes } in
+             store_module state module_name new_source updated;
+             Cmd_success (result, []))))
+
+  (* ── replace: substitute the declaration identified by anchor ─────────── *)
+  | "replace" ->
+    let anchor_json = obj_get "anchor" args in
+    let source      = match obj_get "source" args with String s -> s | _ -> "" in
+    (match resolve_anchor state anchor_json with
+     | Error d -> Cmd_halt d
+     | Ok (module_name, decl_n, ms) ->
+       let parse_result =
+         try let tokens = Lexer.tokenize source in
+             Ok (Parser.parse_program tokens)
+         with Failure msg -> Error msg
+       in
+       (match parse_result with
+        | Error msg -> Cmd_halt (Mcp_types.make_error "parse/error" msg)
+        | Ok new_decls ->
+          let without_old = List.filter (fun d ->
+            match decl_name d with
+            | Some n -> n <> decl_n
+            | None   -> true) ms.typed_ast in
+          let new_ast  = without_old @ new_decls in
+          let (root_hash, decl_hashes) = encode_ast state new_ast in
+          let result   = make_write_result root_hash decl_hashes in
+          let type_result =
+            try Ok (Typechecker.check_program new_ast) with Failure msg -> Error msg
+          in
+          let new_source = Printer.print_program new_ast in
+          (match type_result with
+           | Error msg ->
+             let updated = { typed_ast = new_ast; root_hash; decl_hashes;
+                             type_env = []; effect_env = [] } in
+             store_module state module_name new_source updated;
+             Cmd_success (result, [Mcp_types.make_error "type/error" msg])
+           | Ok (type_env, effect_env) ->
+             let updated = { typed_ast = new_ast; type_env; effect_env;
+                             root_hash; decl_hashes } in
+             store_module state module_name new_source updated;
+             Cmd_success (result, []))))
 
   | _ ->
     Cmd_halt (Mcp_types.make_error "command/unknown"
@@ -1663,9 +1768,12 @@ let tool_write_schema =
   Object [
     ("name", String "write");
     ("description", String
-       "Submit working-form Axiom source; elaborate, typecheck, store, and \
-        automatically verify the resulting state.  Accepts a batch of commands.");
-    ("inputSchema", batch_input_schema ["submit_module"]);
+       "Author working-form Axiom source; elaborate, typecheck, store, and \
+        automatically verify the resulting project state.  Accepts a batch of \
+        commands followed by an optional 'verify' array \
+        (default: [\"types\",\"effects\",\"exhaustive\"]).  \
+        Parse errors halt the batch; type/effect diagnostics are recoverable.");
+    ("inputSchema", batch_input_schema ["module"; "function"; "replace"]);
   ]
 
 let tool_transform_schema =
@@ -1727,8 +1835,14 @@ let handle state msg =
        send (response id (wrap_batch_result
            (batch_execute (dispatch_query state) cmds)))
      | "write" ->
-       send (response id (wrap_batch_result
-           (batch_execute (dispatch_write state) cmds)))
+       let verify_checks = match obj_get "verify" args with
+         | Array vs -> List.filter_map (function String s -> Some s | _ -> None) vs
+         | _        -> ["types"; "effects"; "exhaustive"]
+       in
+       let br        = batch_execute (dispatch_write state) cmds in
+       let post_diags = run_post_batch_verify state verify_checks in
+       let br'       = { br with br_diagnostics = br.br_diagnostics @ post_diags } in
+       send (response id (wrap_batch_result br'))
      | "transform" ->
        send (response id (wrap_batch_result
            (batch_execute (dispatch_transform state) cmds)))

--- a/test/test_mcp_server.ml
+++ b/test/test_mcp_server.ml
@@ -365,22 +365,22 @@ let test_verify_types_does_not_update_state () =
     ignore (read_line ());
     (* write well-typed source — must still succeed *)
     write_line (tool_call 3 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"test"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"test"}|}
             (json_string_escape well_typed_source))));
     let batch = parse_batch_response (read_line ()) in
     Alcotest.(check bool) "write succeeds" true (batch_ok batch)
   )
 
-(* ─── write / submit_module ─────────────────────────────────────────────── *)
+(* ─── write / module ────────────────────────────────────────────────────── *)
 
 let test_write_submit_returns_root_and_nodes () =
   let (write_line, read_line, close) = start_server () in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape well_typed_source))));
     let batch = parse_batch_response (read_line ()) in
     Alcotest.(check bool) "batch ok" true (batch_ok batch);
@@ -407,8 +407,8 @@ fn bar(x: Int) -> Int ! pure { x }|} in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape source))));
     let batch = parse_batch_response (read_line ()) in
     Alcotest.(check bool) "batch ok" true (batch_ok batch);
@@ -424,8 +424,8 @@ let test_write_parse_error_halts () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         {|{"source":"@@@invalid@@@","module_name":"mymod"}|}));
+      (single_cmd "module"
+         {|{"source":"@@@invalid@@@","name":"mymod"}|}));
     let batch = parse_batch_response (read_line ()) in
     Alcotest.(check bool) "batch halted" true (not (batch_ok batch));
     let diags = batch_diagnostics batch in
@@ -444,8 +444,8 @@ let test_query_signature_success () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape well_typed_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -465,8 +465,8 @@ let test_query_signature_by_hash () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape well_typed_source))));
     let submit_batch = parse_batch_response (read_line ()) in
     let double_hash = match json_field "nodes" (first_result submit_batch) with
@@ -503,8 +503,8 @@ let test_query_signature_function_not_found () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape well_typed_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -522,8 +522,8 @@ let test_query_interface_returns_only_pub () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape mixed_visibility_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -542,8 +542,8 @@ let test_query_interface_fn_has_no_body () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape mixed_visibility_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -575,8 +575,8 @@ let test_verify_exhaustive_node_is_fn_hash () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape exhaustive_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -592,8 +592,8 @@ let test_verify_exhaustive_no_warnings () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape exhaustive_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -620,8 +620,8 @@ let test_verify_effects_all_handled () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_all_handled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -636,8 +636,8 @@ let test_verify_effects_unhandled () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_unhandled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -672,8 +672,8 @@ let test_verify_effects_entry_not_found () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_all_handled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -689,8 +689,8 @@ let test_verify_unused_all_used () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape all_used_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -705,8 +705,8 @@ let test_verify_unused_one_unused () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape one_unused_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -733,8 +733,8 @@ let test_verify_unused_pub_not_flagged () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape pub_unused_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -748,8 +748,8 @@ let test_verify_unused_mutual_recursion_both_reachable () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape mutual_recursion_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -764,8 +764,8 @@ let test_verify_unused_mutual_recursion_both_unreachable () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape mutual_both_unused_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -802,8 +802,8 @@ let test_query_effects_pure_module () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape pure_module_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -820,8 +820,8 @@ let test_query_effects_single_effect () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape single_effect_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -843,8 +843,8 @@ let test_query_effects_multi_effect () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape multi_effect_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -874,8 +874,8 @@ let test_query_callers_multiple_callers () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape multi_caller_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -907,8 +907,8 @@ fn main2() -> Int ! pure { helper(2) }|} in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -932,8 +932,8 @@ let test_query_callers_uncalled_function () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape uncalled_fn_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -960,8 +960,8 @@ let test_query_callers_function_not_defined () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape multi_caller_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -977,8 +977,8 @@ let test_batch_multi_command_all_succeed () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape well_typed_source))));
     ignore (read_line ());
     (* Two query commands in one batch *)
@@ -997,8 +997,8 @@ let test_batch_halts_at_first_unrecoverable () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape well_typed_source))));
     ignore (read_line ());
     (* First command fails (module not found), second would succeed *)
@@ -1021,8 +1021,8 @@ let test_verify_effects_diagnostic_has_node () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_unhandled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -1041,8 +1041,8 @@ let test_verify_unused_diagnostic_has_node () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape one_unused_source))));
     ignore (read_line ());
     write_line (tool_call 3 "verify"
@@ -1063,8 +1063,8 @@ let test_query_effect_flow_pure_fn () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_all_handled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1084,8 +1084,8 @@ let test_query_effect_flow_handled_effect () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_all_handled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1105,8 +1105,8 @@ let test_query_effect_flow_unhandled_marked () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_unhandled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1138,8 +1138,8 @@ let test_query_unhandled_all_handled () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_all_handled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1156,8 +1156,8 @@ let test_query_unhandled_returns_sites () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape effects_unhandled_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1193,8 +1193,8 @@ let test_query_dependents_effect () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape single_effect_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1213,8 +1213,8 @@ let test_query_dependents_defines_included () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape single_effect_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1243,8 +1243,8 @@ let test_query_dependents_unknown_name_empty () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape pure_module_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1264,8 +1264,8 @@ let test_query_pattern_coverage_exhaustive () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape exhaustive_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1287,8 +1287,8 @@ let test_query_pattern_coverage_node_present () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape exhaustive_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1317,8 +1317,8 @@ let test_query_graph_has_param () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1341,8 +1341,8 @@ let test_query_graph_has_param_filter () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1366,8 +1366,8 @@ let test_query_graph_calls_in () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape multi_caller_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1403,8 +1403,8 @@ let test_query_graph_calls_out () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape multi_caller_source))));
     ignore (read_line ());
     write_line (tool_call 3 "query"
@@ -1426,8 +1426,8 @@ fn main2() -> Int ! pure { helper(2) }|} in
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape source))));
     ignore (read_line ());
     let cmds = {|{"anchor":{"module":"mymod","name":"helper"},"traverse":[{"edge":"CALLS","direction":"in","collect":"call_sites","follow":{"edge":"HAS_ARGUMENT","direction":"out","collect":"arguments"}}]}|} in
@@ -1447,8 +1447,8 @@ let test_query_graph_batch_with_existing_ops () =
   Fun.protect ~finally:close (fun () ->
     initialize write_line read_line;
     write_line (tool_call 2 "write"
-      (single_cmd "submit_module"
-         (Printf.sprintf {|{"source":"%s","module_name":"mymod"}|}
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
             (json_string_escape mixed_visibility_source))));
     ignore (read_line ());
     let cmds =
@@ -1459,6 +1459,220 @@ let test_query_graph_batch_with_existing_ops () =
     Alcotest.(check bool) "batch ok" true (batch_ok batch);
     let results = match json_field "results" batch with `List rs -> rs | _ -> [] in
     Alcotest.(check int) "three results" 3 (List.length results)
+  )
+
+(* ─── write / module: type errors are recoverable ───────────────────────── *)
+
+let test_write_module_type_error_recoverable () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
+            (json_string_escape ill_typed_source))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch NOT halted (recoverable)" true (batch_ok batch);
+    let r = first_result batch in
+    Alcotest.(check bool) "root hash present" true
+      (match json_field "root" r with `String s -> String.length s > 0 | _ -> false);
+    let diags = batch_diagnostics batch in
+    Alcotest.(check bool) "type error diagnostic present" true (diags <> []);
+    (match diags with
+     | d :: _ ->
+       Alcotest.(check bool) "severity is error" true
+         (json_field "severity" d = `String "error");
+       Alcotest.(check bool) "code starts with type/" true
+         (match json_field "code" d with
+          | `String s -> contains_substring s "type/" | _ -> false)
+     | [] -> ())
+  )
+
+let test_write_module_type_error_then_good_module () =
+  (* A type error in a module op must not halt the batch;
+     a subsequent module op in the same batch must still execute. *)
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    let cmds = Printf.sprintf
+      {|[{"op":"module","args":{"source":"%s","name":"bad"}},{"op":"module","args":{"source":"%s","name":"good"}}]|}
+      (json_string_escape ill_typed_source)
+      (json_string_escape well_typed_source)
+    in
+    write_line (tool_call 2 "write" cmds);
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok (type error is recoverable)" true (batch_ok batch);
+    let results = match json_field "results" batch with `List rs -> rs | _ -> [] in
+    Alcotest.(check int) "two results — both commands ran" 2 (List.length results)
+  )
+
+(* ─── write / function ───────────────────────────────────────────────────── *)
+
+let test_write_function_adds_decl () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    let new_fn = {|fn triple(x: Int) -> Int ! pure { add(x, add(x, x)) }|} in
+    write_line (tool_call 3 "write"
+      (single_cmd "function"
+         (Printf.sprintf {|{"module":"mymod","source":"%s"}|}
+            (json_string_escape new_fn))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let nodes = json_field "nodes" (first_result batch) in
+    Alcotest.(check bool) "original fn still present" true
+      (match nodes with `Assoc fs -> List.mem_assoc "double" fs | _ -> false);
+    Alcotest.(check bool) "new fn present" true
+      (match nodes with `Assoc fs -> List.mem_assoc "triple" fs | _ -> false)
+  )
+
+let test_write_function_replaces_existing_decl () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    let updated_fn = {|fn double(x: Int) -> Int ! pure { add(x, x) }|} in
+    write_line (tool_call 3 "write"
+      (single_cmd "function"
+         (Printf.sprintf {|{"module":"mymod","source":"%s"}|}
+            (json_string_escape updated_fn))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let nodes = json_field "nodes" (first_result batch) in
+    Alcotest.(check bool) "double still in nodes" true
+      (match nodes with `Assoc fs -> List.mem_assoc "double" fs | _ -> false)
+  )
+
+let test_write_function_module_not_found_halts () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "function"
+         {|{"module":"nonexistent","source":"fn f(x: Int) -> Int ! pure { x }"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
+  )
+
+let test_write_function_parse_error_halts () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    write_line (tool_call 3 "write"
+      (single_cmd "function" {|{"module":"mymod","source":"@@@bad@@@"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted on parse error" true (not (batch_ok batch))
+  )
+
+(* ─── write / replace ────────────────────────────────────────────────────── *)
+
+let test_write_replace_by_name () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    ignore (read_line ());
+    let new_body = {|fn double(x: Int) -> Int ! pure { add(x, x) }|} in
+    write_line (tool_call 3 "write"
+      (single_cmd "replace"
+         (Printf.sprintf {|{"anchor":{"module":"mymod","name":"double"},"source":"%s"}|}
+            (json_string_escape new_body))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let nodes = json_field "nodes" (first_result batch) in
+    Alcotest.(check bool) "double still in nodes" true
+      (match nodes with `Assoc fs -> List.mem_assoc "double" fs | _ -> false)
+  )
+
+let test_write_replace_by_hash () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
+            (json_string_escape well_typed_source))));
+    let init_batch = parse_batch_response (read_line ()) in
+    let double_hash = match json_field "nodes" (first_result init_batch) with
+      | `Assoc fs ->
+        (match List.assoc_opt "double" fs with Some (`String h) -> h | _ -> "")
+      | _ -> ""
+    in
+    Alcotest.(check bool) "got double hash" true (String.length double_hash > 0);
+    let new_body = {|fn double(x: Int) -> Int ! pure { add(x, x) }|} in
+    write_line (tool_call 3 "write"
+      (single_cmd "replace"
+         (Printf.sprintf {|{"anchor":{"hash":"%s"},"source":"%s"}|}
+            double_hash (json_string_escape new_body))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok after hash-anchored replace" true (batch_ok batch)
+  )
+
+let test_write_replace_anchor_not_found_halts () =
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "replace"
+         {|{"anchor":{"module":"no_such","name":"fn"},"source":"fn fn() -> Unit ! pure { () }"}|}));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch halted" true (not (batch_ok batch))
+  )
+
+(* ─── write: post-batch verify ───────────────────────────────────────────── *)
+
+let test_write_post_verify_unused_default () =
+  (* The default verify array includes "exhaustive" but NOT "unused", so
+     an unused function in the module should NOT appear in diagnostics
+     unless "unused" is explicitly requested. *)
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    write_line (tool_call 2 "write"
+      (single_cmd "module"
+         (Printf.sprintf {|{"source":"%s","name":"mymod"}|}
+            (json_string_escape one_unused_source))));
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let diags = batch_diagnostics batch in
+    let has_unused = List.exists (fun d ->
+      json_field "code" d = `String "decl/unused") diags in
+    Alcotest.(check bool) "no unused diagnostic with default verify" false has_unused
+  )
+
+let test_write_post_verify_unused_explicit () =
+  (* When verify includes "unused", unused declarations are flagged. *)
+  let (write_line, read_line, close) = start_server () in
+  Fun.protect ~finally:close (fun () ->
+    initialize write_line read_line;
+    let req = Printf.sprintf
+      {|{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"write","arguments":{"commands":[{"op":"module","args":{"source":"%s","name":"mymod"}}],"verify":["unused"]}}}|}
+      (json_string_escape one_unused_source)
+    in
+    write_line req;
+    let batch = parse_batch_response (read_line ()) in
+    Alcotest.(check bool) "batch ok" true (batch_ok batch);
+    let diags = batch_diagnostics batch in
+    let has_unused = List.exists (fun d ->
+      json_field "code" d = `String "decl/unused") diags in
+    Alcotest.(check bool) "unused diagnostic present" true has_unused
   )
 
 (* ─── Test runner ────────────────────────────────────────────────────────── *)
@@ -1473,10 +1687,27 @@ let () =
       Alcotest.test_case "ill-typed source → error diagnostics"  `Quick test_verify_types_ill_typed;
       Alcotest.test_case "does not update server state"          `Quick test_verify_types_does_not_update_state;
     ]);
-    ("write/submit_module", [
+    ("write/module", [
       Alcotest.test_case "returns root hash and nodes map"       `Quick test_write_submit_returns_root_and_nodes;
       Alcotest.test_case "nodes map contains all declarations"   `Quick test_write_submit_nodes_map_all_decls;
       Alcotest.test_case "parse error halts batch"               `Quick test_write_parse_error_halts;
+      Alcotest.test_case "type error is recoverable diagnostic"  `Quick test_write_module_type_error_recoverable;
+      Alcotest.test_case "type error allows next command"        `Quick test_write_module_type_error_then_good_module;
+    ]);
+    ("write/function", [
+      Alcotest.test_case "adds new decl to existing module"      `Quick test_write_function_adds_decl;
+      Alcotest.test_case "replaces existing decl of same name"   `Quick test_write_function_replaces_existing_decl;
+      Alcotest.test_case "module not found halts batch"          `Quick test_write_function_module_not_found_halts;
+      Alcotest.test_case "parse error halts batch"               `Quick test_write_function_parse_error_halts;
+    ]);
+    ("write/replace", [
+      Alcotest.test_case "replace by symbolic anchor"            `Quick test_write_replace_by_name;
+      Alcotest.test_case "replace by hash anchor"                `Quick test_write_replace_by_hash;
+      Alcotest.test_case "anchor not found halts batch"          `Quick test_write_replace_anchor_not_found_halts;
+    ]);
+    ("write/post-verify", [
+      Alcotest.test_case "unused not checked without verify:unused" `Quick test_write_post_verify_unused_default;
+      Alcotest.test_case "verify:unused flags unused decls"         `Quick test_write_post_verify_unused_explicit;
     ]);
     ("query/signature", [
       Alcotest.test_case "returns signature and node hash"       `Quick test_query_signature_success;


### PR DESCRIPTION
## Summary
This PR refactors the write tool to support a more flexible module authoring workflow. The `submit_module` command is renamed to `module`, and two new write operations (`function` and `replace`) are added to allow incremental updates to modules. Type errors are now recoverable (non-halting) while parse errors remain halting.

## Key Changes

- **Renamed `submit_module` → `module`**: The primary write operation for storing complete modules now uses the shorter `module` name. The JSON schema changes from `{"source":"...","module_name":"..."}` to `{"source":"...","name":"..."}`.

- **New `function` operation**: Allows adding or replacing a single function declaration within an existing module without rewriting the entire module. Accepts `{"module":"...","source":"..."}` and merges the new declaration(s) into the module's AST.

- **New `replace` operation**: Enables targeted replacement of a declaration identified by an anchor (either `{"module":"...","name":"..."}` or `{"hash":"..."}`) with new source code.

- **Type errors are now recoverable**: When a module operation encounters a type error, the batch continues executing (non-halting). The module is still stored with an empty type/effect environment, and a type error diagnostic is returned. Parse errors remain halting.

- **Refactored verification logic**: 
  - Extracted `encode_ast()` to centralize AST encoding and hash computation
  - Extracted `make_write_result()` to build the result object structure
  - Extracted `store_module()` to handle module persistence
  - Renamed `post_write_verify()` to `run_post_batch_verify()` and generalized it to iterate over all modules and respect a configurable `verify_checks` list
  - The write tool now accepts an optional `verify` parameter (defaults to `["types", "effects", "exhaustive"]`) to control which post-batch checks run

- **Updated test suite**: All 50+ test cases updated to use the new `module` operation name and JSON schema. Added new tests for type error recoverability and the new `function` and `replace` operations.

## Implementation Details

- Type checking is performed per-command; if it fails, the module is stored with empty type/effect environments but the batch continues
- The `function` and `replace` operations filter out old declarations by name before adding new ones, allowing safe replacement
- Module source is always regenerated via `Printer.print_program` when using `function` or `replace` to maintain consistency
- Post-batch verification (exhaustive matching and unused declarations) runs after all commands complete, collecting diagnostics from all modules in the state

https://claude.ai/code/session_01REVM4qujVa6EVn4kRAG5px