### PR TITLE
Add test suite for examples 02–10 build status triage (#103)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,6 +50,31 @@ shaped the code style — each is a candidate for future parser improvement:
    three-argument `compose_apply(f, g, x)` over curried `compose(f, g)` that
    returns a function, or use a named type alias for the function type.
 
+## Build-status triage (issue \#103)
+
+The table below records the current build status of each example, the exact
+error produced, the failure category, and the GitHub issue(s) whose resolution
+would unblock it.  The `examples_02_10` suite in `test/test_build_pipeline.ml`
+asserts the exact failure mode of each broken example so that CI catches silent
+fixes *and* unexpected new breakage.
+
+| Example | Status | Failure | Category | Blocking issue(s) |
+|---------|--------|---------|----------|-------------------|
+| `01_basics.axm` | ✓ passes | — | — | — |
+| `02_data_types.axm` | ✓ passes | — | — | — |
+| `03_effects.axm` | ✗ fails | `unbound variable 'info'` | Missing lowercase constructor wrappers for user-defined ADTs (e.g. `info` for `Info`, `debug` for `Debug`) | [#109] |
+| `04_state_machine.axm` | ✗ fails | `unbound variable 'transitioned'` | Missing lowercase constructor wrappers for user-defined ADTs | [#109] |
+| `05_collections.axm` | ✗ fails | `unbound variable 'pair'` | Missing stdlib `pair` constructor wrapper | [#109] |
+| `06_string_processing.axm` | ✗ fails | `unbound variable 'string_length'` | Missing stdlib string operations | [#110] |
+| `07_validation.axm` | ✗ fails | `unbound variable 'valid'` | Missing lowercase constructor wrappers for user-defined ADTs | [#109] |
+| `08_config.axm` | ✗ fails | `parse error: unexpected token Perform` | Parser bug — `perform` not accepted as the scrutinee of a `match` expression | [#101] |
+| `09_pipeline.axm` | ✗ fails | `unknown effect 'Log'` | Missing `Log` effect declaration in file scope (declared in `03_effects.axm`; needs import or local redeclaration) | [#109] |
+| `10_json.axm` | ✗ fails | `unbound variable 'j_object'` | Missing lowercase constructor wrappers for user-defined ADTs | [#109] |
+
+[#101]: https://github.com/kendru/axiom/issues/101
+[#109]: https://github.com/kendru/axiom/issues/109
+[#110]: https://github.com/kendru/axiom/issues/110
+
 ## Stdlib functions assumed by examples
 
 The examples call functions that don't exist yet. This list captures what

--- a/test/test_build_pipeline.ml
+++ b/test/test_build_pipeline.ml
@@ -1067,6 +1067,63 @@ let test_validates_flags ~flags src () =
       | Skip msg -> Printf.printf "[SKIP] %s\n%!" msg))
 
 (* ------------------------------------------------------------------ *)
+(* Issue #103: examples 02–10 triage helpers                          *)
+(* ------------------------------------------------------------------ *)
+
+let axiom_build_capture_stderr ~src ~dst =
+  let err_tmp = Filename.temp_file "axiom_stderr_" ".txt" in
+  let cmd =
+    Printf.sprintf "%s build %s -o %s 2>%s"
+      (Filename.quote axiom_exe)
+      (Filename.quote src)
+      (Filename.quote dst)
+      (Filename.quote err_tmp)
+  in
+  let rc = Sys.command cmd in
+  let stderr_out =
+    let ic = open_in err_tmp in
+    let buf = Buffer.create 128 in
+    (try while true do Buffer.add_channel buf ic 1 done
+     with End_of_file -> ());
+    close_in ic;
+    (try Sys.remove err_tmp with _ -> ());
+    Buffer.contents buf
+  in
+  (rc, stderr_out)
+
+let string_contains haystack needle =
+  let hlen = String.length haystack and nlen = String.length needle in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec loop i =
+      if i > hlen - nlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_example_builds path () =
+  if not (Sys.file_exists path) then
+    Printf.printf "[SKIP] %s not found\n%!" path
+  else
+    with_tmp_file ".wasm" (fun d ->
+      let rc, stderr = axiom_build_capture_stderr ~src:path ~dst:d in
+      if rc <> 0 then
+        Alcotest.failf "expected build to succeed, got exit %d\nstderr: %S" rc stderr)
+
+let test_example_fails_with path expected_fragment () =
+  if not (Sys.file_exists path) then
+    Printf.printf "[SKIP] %s not found\n%!" path
+  else
+    with_tmp_file ".wasm" (fun d ->
+      let rc, stderr = axiom_build_capture_stderr ~src:path ~dst:d in
+      Alcotest.(check bool) "non-zero exit" true (rc <> 0);
+      if not (string_contains stderr expected_fragment) then
+        Alcotest.failf "expected stderr to contain %S\ngot: %S"
+          expected_fragment stderr)
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                               *)
 (* ------------------------------------------------------------------ *)
 
@@ -1293,5 +1350,40 @@ fn main() -> Int ! pure { 0 }|};
         ; Alcotest.test_case "validate: 01_basics.axm from disk" `Quick
             (test_validate_file_from_disk
                (Filename.concat examples_dir "01_basics.axm"))
+        ] )
+    ; ( "examples_02_10",
+        (* Issue #103: triage examples 02–10.
+           Each test locks in the exact current build outcome so that CI flags
+           both silent fixes (a broken example starts passing) and unexpected
+           new breakage (a passing example starts failing).
+           Update this suite when an example is genuinely fixed. *)
+        let ex name = Filename.concat examples_dir (name ^ ".axm") in
+        [ Alcotest.test_case "02_data_types builds" `Quick
+            (test_example_builds (ex "02_data_types"))
+          (* 03: missing lowercase constructor wrappers for user-defined ADTs
+             ('info' for Info, etc.) — blocked by #109 *)
+        ; Alcotest.test_case "03_effects: unbound 'info'" `Quick
+            (test_example_fails_with (ex "03_effects") "unbound variable 'info'")
+          (* 04: missing lowercase constructor wrapper 'transitioned' — blocked by #109 *)
+        ; Alcotest.test_case "04_state_machine: unbound 'transitioned'" `Quick
+            (test_example_fails_with (ex "04_state_machine") "unbound variable 'transitioned'")
+          (* 05: missing stdlib 'pair' constructor — blocked by #109 *)
+        ; Alcotest.test_case "05_collections: unbound 'pair'" `Quick
+            (test_example_fails_with (ex "05_collections") "unbound variable 'pair'")
+          (* 06: missing stdlib string operations — blocked by #110 *)
+        ; Alcotest.test_case "06_string_processing: unbound 'string_length'" `Quick
+            (test_example_fails_with (ex "06_string_processing") "unbound variable 'string_length'")
+          (* 07: missing lowercase constructor wrappers 'valid'/'invalid' — blocked by #109 *)
+        ; Alcotest.test_case "07_validation: unbound 'valid'" `Quick
+            (test_example_fails_with (ex "07_validation") "unbound variable 'valid'")
+          (* 08: parser bug — 'perform' not accepted as match scrutinee — blocked by #101 *)
+        ; Alcotest.test_case "08_config: parse error on Perform" `Quick
+            (test_example_fails_with (ex "08_config") "unexpected token Perform")
+          (* 09: 'Log' effect used but not declared in file scope — blocked by #109 *)
+        ; Alcotest.test_case "09_pipeline: unknown effect 'Log'" `Quick
+            (test_example_fails_with (ex "09_pipeline") "unknown effect 'Log'")
+          (* 10: missing lowercase constructor wrappers for Json ADT — blocked by #109 *)
+        ; Alcotest.test_case "10_json: unbound 'j_object'" `Quick
+            (test_example_fails_with (ex "10_json") "unbound variable 'j_object'")
         ] )
     ]


### PR DESCRIPTION
## Summary

This PR adds a comprehensive test suite to track and enforce the build status of examples 02–10, ensuring that CI catches both silent fixes and unexpected regressions. Each broken example now has a test that asserts the exact error message it produces.

## Key Changes

- **New test helpers in `test/test_build_pipeline.ml`**:
  - `axiom_build_capture_stderr`: Executes the axiom build command and captures stderr output
  - `string_contains`: Helper function to check if stderr contains expected error fragments
  - `test_example_builds`: Asserts that an example builds successfully
  - `test_example_fails_with`: Asserts that an example fails with a specific error message

- **New `examples_02_10` test suite**: 
  - Tests example 02 (data_types) which currently passes
  - Tests examples 03–10 which currently fail, each locked to its specific error message
  - Each test includes a comment documenting the failure category and blocking GitHub issue(s)

- **Updated `examples/README.md`**:
  - Added "Build-status triage" section with a table showing the status of each example
  - Documents the exact failure mode, category, and blocking issues for each broken example
  - Links to relevant GitHub issues (#101, #109, #110)

## Implementation Details

The test suite uses a "lock-in" approach where each broken example's exact error message is asserted. This ensures that:
- Silent fixes (a broken example starts passing) are caught by test failure
- Unexpected new breakage (a passing example starts failing) is caught by test failure
- The test suite serves as living documentation of known issues and their blockers

All broken examples are blocked by one of three issues:
- **#109**: Missing lowercase constructor wrappers for user-defined ADTs and stdlib types
- **#110**: Missing stdlib string operations
- **#101**: Parser bug with `perform` as match scrutinee

https://claude.ai/code/session_014EgGit4npqxL3FV6cB1YxA