### PR TITLE
Implement record construction, projection, and functional update

### DIFF
--- a/docs/implementation/codegen.md
+++ b/docs/implementation/codegen.md
@@ -241,6 +241,65 @@ bytes.  The emitter calls `__alloc(4 * (1 + k))`, then uses
 `__heap_ptr` starts at 1024 (also a multiple of 4), so all word
 accesses are naturally aligned.
 
+### Structural record layout
+
+`TyRecord` values are heap-allocated blocks with **no tag word**.  Fields
+are laid out contiguously in **canonical alphabetical order** — the same
+order the elaboration pass fixes for every `ERecord` node.
+
+```
+offset 0           : i32  field[0]   (first field alphabetically)
+offset 4           : i32  field[1]
+...
+offset 4*(n-1)     : i32  field[n-1] (last field alphabetically)
+```
+
+**Allocation size** for a record with `n` fields is `4 * n` bytes.
+
+**Canonicalization rule**: field names are sorted with `String.compare`
+(byte-wise lexicographic order, equivalent to alphabetical for ASCII
+identifiers).  The elaboration pass (`elaboration.ml`) sorts every
+`ERecord`'s field list before codegen sees it, so the codegen can rely
+on position `i` corresponding to the `i`-th name in this sorted order.
+
+**Construction** (`ERecord fields`):
+
+```
+alloc(n * 4)  → ptr
+ptr + 0*4 ← compile(field[0].value)
+ptr + 1*4 ← compile(field[1].value)
+...
+result: ptr
+```
+
+**Projection** (`EProject(base, field, idx)`):
+
+The elaboration pass resolves `field` to its 0-based index `idx` in the
+sorted field list at elaboration time.  Codegen emits:
+
+```
+compile(base)
+i32.load offset=(idx * 4)
+```
+
+**Functional update** (`ERecordUpdate(base, updates, all_field_names)`):
+
+Allocates a fresh record of the same size.  For each field (in sorted
+order), if the field appears in `updates` the new expression is used;
+otherwise the original value is copied from the base pointer.
+Aliasing of the original record is therefore never observable.
+
+```
+base_ptr ← compile(base)
+new_ptr  ← alloc(n * 4)
+for i, name in enumerate(all_field_names):
+    if name in updates:
+        new_ptr + i*4 ← compile(updates[name])
+    else:
+        new_ptr + i*4 ← i32.load(base_ptr + i*4)
+result: new_ptr
+```
+
 ---
 
 ## End-to-end pipeline (Milestone 5)

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -277,8 +277,8 @@ and compile_eexpr ?(tail=false) ctx e =
     let (tag, _) = List.assoc name ctx.ctor_map in
     compile_ctor ctx tag args
 
-  (* Module-qualified function call: mod.fn(args) *)
-  | EApp ({ edesc = EProject ({ edesc = EVar mod_name; _ }, fn_name); _ }, args) ->
+  (* Module-qualified function call: mod.fn(args) — index is unused here *)
+  | EApp ({ edesc = EProject ({ edesc = EVar mod_name; _ }, fn_name, _); _ }, args) ->
     let qualified = mod_name ^ "." ^ fn_name in
     (match List.assoc_opt qualified ctx.func_map with
      | Some idx ->
@@ -370,6 +370,50 @@ and compile_eexpr ?(tail=false) ctx e =
     (match List.assoc_opt s ctx.string_pool with
      | Some off -> [I32Const off]
      | None -> failwith ("Codegen: string literal not in pool: " ^ String.escaped s))
+
+  (* ── Record construction ─────────────────────────────────────────────
+     Layout: heap-allocated block of n × 4 bytes.  Field i (in canonical
+     alphabetical order) lives at byte offset i × 4.  The elaboration pass
+     guarantees that [fields] are already sorted alphabetically. *)
+  | ERecord fields ->
+    let n = List.length fields in
+    if n = 0 then
+      [I32Const 0]   (* empty record is represented as a null pointer *)
+    else
+      let ptr_local = alloc_local ctx in
+      [I32Const (n * 4); Call ctx.alloc_idx; LocalSet ptr_local]
+      @ List.concat (List.mapi (fun i (_, v) ->
+          [LocalGet ptr_local]
+          @ compile_eexpr ctx v
+          @ [I32Store (2, i * 4)]
+        ) fields)
+      @ [LocalGet ptr_local]
+
+  (* ── Record field projection ─────────────────────────────────────────
+     Load the i32 value at offset [idx × 4] from the record pointer. *)
+  | EProject (base, _field, idx) ->
+    compile_eexpr ctx base @ [I32Load (2, idx * 4)]
+
+  (* ── Functional record update ────────────────────────────────────────
+     Allocate a fresh record of the same size.  For each field (in sorted
+     order): if it is listed in [updates], emit the new value; otherwise
+     copy the original value from [base_ptr + offset]. *)
+  | ERecordUpdate (base, updates, all_field_names) ->
+    let n = List.length all_field_names in
+    let base_local = alloc_local ctx in
+    let new_ptr_local = alloc_local ctx in
+    compile_eexpr ctx base
+    @ [LocalSet base_local]
+    @ [I32Const (n * 4); Call ctx.alloc_idx; LocalSet new_ptr_local]
+    @ List.concat (List.mapi (fun i field_name ->
+        let value_instrs =
+          match List.assoc_opt field_name updates with
+          | Some update_expr -> compile_eexpr ctx update_expr
+          | None             -> [LocalGet base_local; I32Load (2, i * 4)]
+        in
+        [LocalGet new_ptr_local] @ value_instrs @ [I32Store (2, i * 4)]
+      ) all_field_names)
+    @ [LocalGet new_ptr_local]
 
   | other ->
     failwith (Format.asprintf "Codegen: unsupported eexpr: %a" pp_eexpr { edesc = other })
@@ -511,10 +555,10 @@ let rec scan_eexpr_strings acc e =
       (scan_eexpr_strings acc body) bindings
   | ERecord fields ->
     List.fold_left (fun a (_, e2) -> scan_eexpr_strings a e2) acc fields
-  | ERecordUpdate (e2, fields) ->
+  | ERecordUpdate (e2, fields, _) ->
     List.fold_left (fun a (_, fe) -> scan_eexpr_strings a fe)
       (scan_eexpr_strings acc e2) fields
-  | EProject (e2, _) -> scan_eexpr_strings acc e2
+  | EProject (e2, _, _) -> scan_eexpr_strings acc e2
   | EPerform { args; _ } -> List.fold_left scan_eexpr_strings acc args
   | EHandle { handled; handlers } ->
     let acc' = scan_eexpr_strings acc handled in

--- a/lib/elaboration.ml
+++ b/lib/elaboration.ml
@@ -59,8 +59,11 @@ and eexpr_desc =
   | EDo           of edo_stmt list
   | ELetrec       of eletrec_binding list * eexpr
   | ERecord       of (string * eexpr) list
-  | ERecordUpdate of eexpr * (string * eexpr) list
-  | EProject      of eexpr * string
+                     (** Fields are always in canonical alphabetical order. *)
+  | ERecordUpdate of eexpr * (string * eexpr) list * string list
+                     (** base * updates * all_field_names_sorted *)
+  | EProject      of eexpr * string * int
+                     (** base * field_name * field_index_in_sorted_layout *)
   | EPerform      of eperform_data
   | EHandle       of ehandle_data
 
@@ -218,10 +221,53 @@ let effects_of_callee fn_env (e : Ast.expr) =
   | _ -> []
 
 (* ------------------------------------------------------------------ *)
+(* Record field-layout helpers                                          *)
+(* ------------------------------------------------------------------ *)
+
+(** Sort a list of record fields into canonical (alphabetical) order. *)
+let sort_fields fields =
+  List.sort (fun (a, _) (b, _) -> String.compare a b) fields
+
+(** Given a typechecker [ty], return the sorted list of field names for
+    the record type.  Raises [Failure] if [ty] is not a record type. *)
+let sorted_field_names_of_ty ty =
+  match Typechecker.deref ty with
+  | Typechecker.TyRecord (fields, tail) ->
+    let all_fields, _ = Typechecker.flatten_record fields tail in
+    let sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) all_fields in
+    List.map fst sorted
+  | other ->
+    failwith (Format.asprintf "Elaboration: expected record type, got %a"
+                Typechecker.pp_ty other)
+
+(** Find the index of [field_name] in [sorted_names].  Returns 0 on
+    failure (used for module-qualified references where the index is
+    never used as a memory offset). *)
+let field_index sorted_names field_name =
+  let rec go i = function
+    | []           -> 0
+    | n :: rest    -> if n = field_name then i else go (i + 1) rest
+  in
+  go 0 sorted_names
+
+(** Try to infer the type of [e] with the given typechecker context.
+    Returns [None] on failure (e.g. [e] is a module reference that is
+    not in the type environment). *)
+let try_infer_type tc_eenv tc_env e =
+  try Some (Typechecker.infer_expr_in tc_eenv tc_env Typechecker.RPure e)
+  with _ -> None
+
+(* ------------------------------------------------------------------ *)
 (* Main elaboration                                                     *)
 (* ------------------------------------------------------------------ *)
 
-let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env) (e : Ast.expr) : eexpr =
+(** [elaborate_expr fn_env ev_env tc_env tc_eenv e] elaborates [e].
+    [tc_env] and [tc_eenv] are threaded from the typechecker so that
+    record operations can resolve field layouts at elaboration time.
+    [tc_env] is extended as let/do bindings are processed. *)
+let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env)
+    (tc_env : Typechecker.env) (tc_eenv : Typechecker.effect_env)
+    (e : Ast.expr) : eexpr =
   match e.desc with
   | Var x       -> eexpr (EVar x)
   | IntLit n    -> eexpr (EIntLit n)
@@ -232,15 +278,24 @@ let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env) (e : Ast.expr) : eexp
 
   | Let { pat; value; body } ->
     let fn_env' = fn_env_extend_let fn_env pat value in
+    (* Extend tc_env so that the body can resolve record types bound here. *)
+    let body_tc_env = match pat.pat_desc with
+      | PVar x ->
+        (match try_infer_type tc_eenv tc_env value with
+         | Some vty ->
+           Typechecker.env_extend x (Typechecker.mono vty) tc_env
+         | None -> tc_env)
+      | _ -> tc_env
+    in
     eexpr (ELet {
       pat;
-      value = elaborate_expr fn_env  ev_env value;
-      body  = elaborate_expr fn_env' ev_env body;
+      value = elaborate_expr fn_env  ev_env tc_env       tc_eenv value;
+      body  = elaborate_expr fn_env' ev_env body_tc_env  tc_eenv body;
     })
 
   | App (callee, args) ->
-    let ecallee = elaborate_expr fn_env ev_env callee in
-    let eargs   = List.map (elaborate_expr fn_env ev_env) args in
+    let ecallee = elaborate_expr fn_env ev_env tc_env tc_eenv callee in
+    let eargs   = List.map (elaborate_expr fn_env ev_env tc_env tc_eenv) args in
     let callee_effs = effects_of_callee fn_env callee in
     let ev_args = List.filter_map (fun eff ->
         match List.assoc_opt eff ev_env with
@@ -255,16 +310,22 @@ let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env) (e : Ast.expr) : eexp
     let ev_env' = List.fold_left
         (fun acc ep -> (ep.ev_effect, ep.ev_name) :: acc)
         ev_env ev_params in
+    (* Extend tc_env with param types for the body. *)
+    let body_tc_env = List.fold_left (fun env p ->
+        Typechecker.env_extend p.param_name
+          (Typechecker.mono (Typechecker.ty_of_type_expr p.param_type))
+          env
+      ) tc_env params in
     eexpr (EFn {
       ev_params;
       params;
       return_type;
       effects;
-      fn_body = elaborate_expr fn_env ev_env' fn_body;
+      fn_body = elaborate_expr fn_env ev_env' body_tc_env tc_eenv fn_body;
     })
 
   | Perform { effect_name; op_name; args } ->
-    let eargs = List.map (elaborate_expr fn_env ev_env) args in
+    let eargs = List.map (elaborate_expr fn_env ev_env tc_env tc_eenv) args in
     let ev_var =
       match List.assoc_opt effect_name ev_env with
       | Some v -> v
@@ -283,12 +344,12 @@ let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env) (e : Ast.expr) : eexp
         let eop_handlers = List.map (fun (oh : Ast.op_handler) ->
             { op_handler_name   = oh.op_handler_name;
               op_handler_params = oh.op_handler_params;
-              op_handler_body   = elaborate_expr fn_env ev_env oh.op_handler_body;
+              op_handler_body   = elaborate_expr fn_env ev_env tc_env tc_eenv oh.op_handler_body;
             }
           ) h.op_handlers in
         let ereturn = Option.map (fun (rh : Ast.return_handler) ->
             { return_var  = rh.return_var;
-              return_body = elaborate_expr fn_env ev_env rh.return_body;
+              return_body = elaborate_expr fn_env ev_env tc_env tc_eenv rh.return_body;
             }
           ) h.return_handler in
         { effect_handler = h.effect_handler;
@@ -302,38 +363,46 @@ let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env) (e : Ast.expr) : eexp
         (h.effect_handler, ev_var_name h.effect_handler) :: acc
       ) ev_env handlers in
     eexpr (EHandle {
-      handled  = elaborate_expr fn_env ev_env' handled;
+      handled  = elaborate_expr fn_env ev_env' tc_env tc_eenv handled;
       handlers = ehandlers;
     })
 
   | Match { scrutinee; arms } ->
     eexpr (EMatch {
-      scrutinee = elaborate_expr fn_env ev_env scrutinee;
+      scrutinee = elaborate_expr fn_env ev_env tc_env tc_eenv scrutinee;
       arms = List.map (fun (a : Ast.match_arm) ->
           { pattern  = a.pattern;
-            arm_body = elaborate_expr fn_env ev_env a.arm_body;
+            arm_body = elaborate_expr fn_env ev_env tc_env tc_eenv a.arm_body;
           }) arms;
     })
 
   | If { cond; then_; else_ } ->
     eexpr (EIf {
-      cond  = elaborate_expr fn_env ev_env cond;
-      then_ = elaborate_expr fn_env ev_env then_;
-      else_ = elaborate_expr fn_env ev_env else_;
+      cond  = elaborate_expr fn_env ev_env tc_env tc_eenv cond;
+      then_ = elaborate_expr fn_env ev_env tc_env tc_eenv then_;
+      else_ = elaborate_expr fn_env ev_env tc_env tc_eenv else_;
     })
 
   | Do stmts ->
-    let rec go fn_env stmts =
+    let rec go fn_env tc_env stmts =
       match stmts with
       | [] -> []
       | StmtLet { pat; value } :: rest ->
         let fn_env' = fn_env_extend_let fn_env pat value in
-        EStmtLet { pat; value = elaborate_expr fn_env ev_env value }
-        :: go fn_env' rest
+        let next_tc_env = match pat.pat_desc with
+          | PVar x ->
+            (match try_infer_type tc_eenv tc_env value with
+             | Some vty ->
+               Typechecker.env_extend x (Typechecker.mono vty) tc_env
+             | None -> tc_env)
+          | _ -> tc_env
+        in
+        EStmtLet { pat; value = elaborate_expr fn_env ev_env tc_env tc_eenv value }
+        :: go fn_env' next_tc_env rest
       | StmtExpr e :: rest ->
-        EStmtExpr (elaborate_expr fn_env ev_env e) :: go fn_env rest
+        EStmtExpr (elaborate_expr fn_env ev_env tc_env tc_eenv e) :: go fn_env tc_env rest
     in
-    eexpr (EDo (go fn_env stmts))
+    eexpr (EDo (go fn_env tc_env stmts))
 
   | Letrec (bindings, body) ->
     (* Letrec bindings have no effect annotation in the surface AST; they
@@ -341,28 +410,61 @@ let rec elaborate_expr (fn_env : fn_env) (ev_env : ev_env) (e : Ast.expr) : eexp
     let fn_env' = List.fold_left
         (fun acc (b : Ast.letrec_binding) -> (b.letrec_name, []) :: acc)
         fn_env bindings in
+    let tc_env' = List.fold_left (fun env (b : Ast.letrec_binding) ->
+        Typechecker.env_extend b.letrec_name
+          (Typechecker.mono (Typechecker.ty_of_type_expr b.letrec_return_type))
+          env
+      ) tc_env bindings in
     let ebindings = List.map (fun (b : Ast.letrec_binding) ->
         { letrec_name        = b.letrec_name;
           letrec_ev_params   = [];
           letrec_params      = b.letrec_params;
           letrec_return_type = b.letrec_return_type;
-          letrec_body        = elaborate_expr fn_env' ev_env b.letrec_body;
+          letrec_body        = elaborate_expr fn_env' ev_env tc_env' tc_eenv b.letrec_body;
         }
       ) bindings in
-    eexpr (ELetrec (ebindings, elaborate_expr fn_env' ev_env body))
+    eexpr (ELetrec (ebindings, elaborate_expr fn_env' ev_env tc_env' tc_eenv body))
 
   | Record fields ->
+    (* Canonical layout: fields in alphabetical order. *)
+    let sorted = sort_fields fields in
     eexpr (ERecord (List.map (fun (n, v) ->
-        (n, elaborate_expr fn_env ev_env v)) fields))
+        (n, elaborate_expr fn_env ev_env tc_env tc_eenv v)) sorted))
 
-  | RecordUpdate (e, fields) ->
+  | RecordUpdate (base, updates) ->
+    (* Determine the full sorted field list from the base's inferred type. *)
+    let all_field_names =
+      match try_infer_type tc_eenv tc_env base with
+      | Some ty -> (try sorted_field_names_of_ty ty
+                    with Failure msg ->
+                      failwith ("Elaboration: RecordUpdate: " ^ msg))
+      | None ->
+        failwith "Elaboration: RecordUpdate: cannot determine base record type"
+    in
     eexpr (ERecordUpdate (
-      elaborate_expr fn_env ev_env e,
-      List.map (fun (n, v) -> (n, elaborate_expr fn_env ev_env v)) fields
+      elaborate_expr fn_env ev_env tc_env tc_eenv base,
+      List.map (fun (n, v) ->
+          (n, elaborate_expr fn_env ev_env tc_env tc_eenv v)) updates,
+      all_field_names
     ))
 
   | Project (e, field) ->
-    eexpr (EProject (elaborate_expr fn_env ev_env e, field))
+    (* Determine the field index for record accesses.  Returns 0 for
+       module-qualified references (EVar of a module name) which are not in
+       the type environment; the index is unused in that context because
+       module-qualified EProject nodes only appear inside EApp. *)
+    let idx =
+      match try_infer_type tc_eenv tc_env e with
+      | Some ty ->
+        (match Typechecker.deref ty with
+         | Typechecker.TyRecord (fields, tail) ->
+           let all_fields, _ = Typechecker.flatten_record fields tail in
+           let sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) all_fields in
+           field_index (List.map fst sorted) field
+         | _ -> 0)
+      | None -> 0
+    in
+    eexpr (EProject (elaborate_expr fn_env ev_env tc_env tc_eenv e, field, idx))
 
 (** Build a fn_env from a list of top-level (or module-level) declarations.
     Functions inside [DeclModule] are included with their qualified name
@@ -382,30 +484,42 @@ let fn_env_of_decls decls =
   in
   List.concat_map (collect None) decls
 
-let rec elaborate_decl (fn_env : fn_env) (d : Ast.decl) : edecl =
+let rec elaborate_decl (fn_env : fn_env)
+    (tc_env : Typechecker.env) (tc_eenv : Typechecker.effect_env)
+    (d : Ast.decl) : edecl =
   match d.decl_desc with
   | DeclFn { pub; fn_name; type_params; params; return_type; effects; decl_body } ->
     let eff_names = effects_of_set effects in
     let ev_params = List.map make_ev_param eff_names in
     let ev_env    = List.map (fun ep -> (ep.ev_effect, ep.ev_name)) ev_params in
+    (* Extend tc_env with the declared parameter types for body elaboration. *)
+    let body_tc_env = List.fold_left (fun env p ->
+        Typechecker.env_extend p.param_name
+          (Typechecker.mono (Typechecker.ty_of_type_expr p.param_type))
+          env
+      ) tc_env params in
     { edecl_desc = EDeclFn {
         pub; fn_name; type_params; ev_params; params; return_type; effects;
-        decl_body = elaborate_expr fn_env ev_env decl_body;
+        decl_body = elaborate_expr fn_env ev_env body_tc_env tc_eenv decl_body;
       }
     }
   | DeclModule { pub; module_name; body } ->
     let fn_env' = fn_env_of_decls body in
     { edecl_desc = EDeclModule {
         pub; module_name;
-        body = List.map (elaborate_decl fn_env') body;
+        body = List.map (elaborate_decl fn_env' tc_env tc_eenv) body;
       }
     }
   | other ->
     { edecl_desc = EDeclPassthrough other }
 
 let elaborate_program (prog : Ast.program) : eprogram =
+  (* Run check_program to obtain a type environment for record layout
+     resolution during elaboration.  The program has already been validated
+     by the caller; this second call always succeeds. *)
+  let (tc_env, tc_eenv) = Typechecker.check_program prog in
   let fn_env = fn_env_of_decls prog in
-  List.map (elaborate_decl fn_env) prog
+  List.map (elaborate_decl fn_env tc_env tc_eenv) prog
 
 (* ------------------------------------------------------------------ *)
 (* Pretty-printer (for dump / round-trip tests)                        *)
@@ -494,15 +608,15 @@ let rec pp_eexpr fmt e =
          ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
          (fun f (n, v) -> Format.fprintf f "%s = %a" n pp_eexpr v)) fields
 
-  | ERecordUpdate (e, fields) ->
+  | ERecordUpdate (e, fields, _all) ->
     Format.fprintf fmt "{ %a with %a }"
       pp_eexpr e
       (Format.pp_print_list
          ~pp_sep:(fun f () -> Format.pp_print_string f ", ")
          (fun f (n, v) -> Format.fprintf f "%s = %a" n pp_eexpr v)) fields
 
-  | EProject (e, field) ->
-    Format.fprintf fmt "%a.%s" pp_eexpr e field
+  | EProject (e, field, idx) ->
+    Format.fprintf fmt "%a.%s[%d]" pp_eexpr e field idx
 
 and pp_eeffect_handler fmt h =
   Format.fprintf fmt "%s[ev:%s] { %a%a }"

--- a/test/test_build_pipeline.ml
+++ b/test/test_build_pipeline.ml
@@ -1190,6 +1190,66 @@ let test_example_main_returns path expected () =
       | RunSkip m -> Printf.printf "[SKIP] %s\n%!" m)
 
 (* ------------------------------------------------------------------ *)
+(* Issue #106: record fixtures                                         *)
+(* ------------------------------------------------------------------ *)
+
+(* Construct {x: 10, y: 20} and project x — result 10. *)
+let src_record_project =
+  {|fn main() -> Int ! pure {
+  let r = { x: 10, y: 20 } in
+  r.x
+}|}
+
+(* Same record, project y — result 20. *)
+let src_record_project_y =
+  {|fn main() -> Int ! pure {
+  let r = { x: 10, y: 20 } in
+  r.y
+}|}
+
+(* Functional update: { r with x: 99 }.x should be 99. *)
+let src_record_update =
+  {|fn main() -> Int ! pure {
+  let r = { x: 10, y: 20 } in
+  let r2 = { r with x: 99 } in
+  r2.x
+}|}
+
+(* After { r with x: 99 }, the unchanged field y should still be 20. *)
+let src_record_update_other_field =
+  {|fn main() -> Int ! pure {
+  let r = { x: 10, y: 20 } in
+  let r2 = { r with x: 99 } in
+  r2.y
+}|}
+
+(* Aliasing: update must not mutate original — r.x stays 10 after update. *)
+let src_record_update_no_alias =
+  {|fn main() -> Int ! pure {
+  let r = { x: 10, y: 20 } in
+  let _r2 = { r with x: 99 } in
+  r.x
+}|}
+
+(* Three-field record with alphabetical layout a, b, c; project b = 2. *)
+let src_record_three_fields =
+  {|fn main() -> Int ! pure {
+  let r = { a: 1, b: 2, c: 3 } in
+  r.b
+}|}
+
+(* Record constructed inside a function using parameters; project inside callee. *)
+let src_record_fn_param =
+  {|fn get_x(x: Int, y: Int) -> Int ! pure {
+  let r = { x: x, y: y } in
+  r.x
+}
+
+fn main() -> Int ! pure {
+  get_x(42, 7)
+}|}
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                               *)
 (* ------------------------------------------------------------------ *)
 
@@ -1483,5 +1543,36 @@ fn main() -> Int ! pure { 0 }|};
             (test_main_returns src_string_head_empty 0)
         ; Alcotest.test_case "triple concat length = 3"            `Quick
             (test_main_returns src_string_triple_concat 3)
+        ] )
+
+    (* ------------------------------------------------------------------ *)
+    (* Issue #106: record construction, projection, and functional update  *)
+    (* ------------------------------------------------------------------ *)
+    ; ( "records",
+        (* Layout: heap-allocated block of n×4 bytes.  Fields stored in
+           canonical alphabetical order, so field i lives at byte offset i×4.
+           Functional update allocates a fresh record; aliasing is not reused. *)
+        [ Alcotest.test_case "build: record construction"          `Quick
+            (test_build_produces_file src_record_project)
+        ; Alcotest.test_case "validates: record construction"      `Quick
+            (test_validates src_record_project)
+        ; Alcotest.test_case "record project x = 10"               `Quick
+            (test_main_returns src_record_project 10)
+        ; Alcotest.test_case "record project y = 20"               `Quick
+            (test_main_returns src_record_project_y 20)
+        ; Alcotest.test_case "build: record update"                `Quick
+            (test_build_produces_file src_record_update)
+        ; Alcotest.test_case "validates: record update"            `Quick
+            (test_validates src_record_update)
+        ; Alcotest.test_case "record update x = 99"                `Quick
+            (test_main_returns src_record_update 99)
+        ; Alcotest.test_case "update preserves other fields"       `Quick
+            (test_main_returns src_record_update_other_field 20)
+        ; Alcotest.test_case "update does not alias original"      `Quick
+            (test_main_returns src_record_update_no_alias 10)
+        ; Alcotest.test_case "three-field record, project middle"  `Quick
+            (test_main_returns src_record_three_fields 2)
+        ; Alcotest.test_case "record passed to fn, project inside" `Quick
+            (test_main_returns src_record_fn_param 42)
         ] )
     ]

--- a/test/test_elaboration.ml
+++ b/test/test_elaboration.ml
@@ -56,10 +56,10 @@ let rec collect_performs acc e =
       (collect_performs acc body) bs
   | ERecord fields ->
     List.fold_left (fun a (_, v) -> collect_performs a v) acc fields
-  | ERecordUpdate (e, fields) ->
+  | ERecordUpdate (e, fields, _) ->
     List.fold_left (fun a (_, v) -> collect_performs a v)
       (collect_performs acc e) fields
-  | EProject (e, _) -> collect_performs acc e
+  | EProject (e, _, _) -> collect_performs acc e
   | _ -> acc
 
 (* ------------------------------------------------------------------ *)


### PR DESCRIPTION
## Summary

This PR implements support for structural records in the compiler, including construction, field projection, and functional update operations. Records are heap-allocated blocks with fields stored in canonical alphabetical order, enabling efficient field access by index.

## Key Changes

- **Record type elaboration**: Extended `ERecord`, `EProject`, and `ERecordUpdate` AST nodes to include field layout information computed at elaboration time
  - `ERecord`: Fields are sorted alphabetically before codegen
  - `EProject(base, field, idx)`: Now includes the 0-based field index in the sorted layout
  - `ERecordUpdate(base, updates, all_field_names)`: Includes the complete sorted field list for fresh allocation

- **Type-aware elaboration**: Modified `elaborate_expr` and `elaborate_decl` to thread typechecker environment (`tc_env`, `tc_eenv`) through the elaboration pass, enabling resolution of record field layouts at elaboration time
  - Added `sorted_field_names_of_ty` to extract sorted field names from record types
  - Added `field_index` to compute 0-based field positions
  - Added `try_infer_type` for safe type inference during elaboration
  - Extended `Let`, `Fn`, `Do`, and `Letrec` to propagate type information for nested bindings

- **Codegen implementation**: Added WebAssembly code generation for record operations
  - **Construction**: Allocates `n × 4` bytes and stores field values at offsets `i × 4`
  - **Projection**: Loads i32 value at offset `idx × 4` from record pointer
  - **Functional update**: Allocates fresh record, copies unchanged fields from base, inserts updated values

- **Documentation**: Updated `codegen.md` with detailed record layout specification and code generation strategy

- **Test coverage**: Added 10 test cases covering record construction, projection, functional update, aliasing semantics, and multi-field records

## Implementation Details

- Records use **no tag word** — they are pure data blocks with fields in alphabetical order
- Field layout is determined at elaboration time by querying the typechecker's type environment
- Functional updates never alias the original record (fresh allocation for each update)
- Empty records are represented as null pointers (0)
- All field accesses are naturally aligned (4-byte boundaries)

https://claude.ai/code/session_017Bc4tZPkJ7a2SAxTHh2Way